### PR TITLE
Webhook engine 

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -16,3 +16,4 @@ logs
 dashboard/node_modules/
 recordings/*.csv
 recordings/*.json
+webhooks.json

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -16,6 +16,7 @@ import UpdateBanner from "./components/UpdateBanner";
 import ShortcutHelp from "./components/ShortcutHelp";
 import ChatPanel from "./components/ChatPanel";
 import WebhookPanel from "./components/WebhookPanel";
+import { useWebhooks } from "./hooks/useWebhooks";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { NUM_CHANNELS } from "./types";
 import type { SelectOption } from "./types";
@@ -54,8 +55,21 @@ export default function App() {
   const [showStats, setShowStats] = useState(false);
   const [showChat, setShowChat] = useState(false);
   const [showWebhooks, setShowWebhooks] = useState(false);
+  const [webhooksEnabled, setWebhooksEnabled] = useState(
+    () => localStorage.getItem("pieeg_webhooks_enabled") === "true"
+  );
   const eeg = useEEG(timeWindow);
   const numCh = eeg.numChannels;
+
+  const toggleWebhooksEnabled = useCallback(() => {
+    setWebhooksEnabled((prev) => {
+      const next = !prev;
+      localStorage.setItem("pieeg_webhooks_enabled", String(next));
+      return next;
+    });
+  }, []);
+
+  const webhooks = useWebhooks(webhooksEnabled, eeg.data, eeg.sendCommand);
 
   const allChannels = new Set(Array.from({ length: numCh }, (_, i) => i));
 
@@ -305,7 +319,7 @@ export default function App() {
           className={`btn${showWebhooks ? " active" : ""}`}
           onClick={() => setShowWebhooks((v) => !v)}
         >
-          Webhooks
+          Webhooks{webhooksEnabled && <span className="wh-active-dot" />}
         </button>
         <button
           className="btn btn-xr"
@@ -506,8 +520,10 @@ export default function App() {
       <WebhookPanel
         open={showWebhooks}
         onClose={() => setShowWebhooks(false)}
-        sendCommand={eeg.sendCommand}
         numChannels={numCh}
+        webhooks={webhooks}
+        webhooksEnabled={webhooksEnabled}
+        onToggleEnabled={toggleWebhooksEnabled}
       />
 
       {/* Keyboard shortcut help (press ? to toggle) */}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import StatsPanel from "./components/StatsPanel";
 import UpdateBanner from "./components/UpdateBanner";
 import ShortcutHelp from "./components/ShortcutHelp";
 import ChatPanel from "./components/ChatPanel";
+import WebhookPanel from "./components/WebhookPanel";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { NUM_CHANNELS } from "./types";
 import type { SelectOption } from "./types";
@@ -52,6 +53,7 @@ export default function App() {
   const [showSpectrogram, setShowSpectrogram] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const [showChat, setShowChat] = useState(false);
+  const [showWebhooks, setShowWebhooks] = useState(false);
   const eeg = useEEG(timeWindow);
   const numCh = eeg.numChannels;
 
@@ -169,6 +171,9 @@ export default function App() {
           break;
         case "KeyC":
           setShowChat((v) => !v);
+          break;
+        case "KeyW":
+          setShowWebhooks((v) => !v);
           break;
         case "KeyG":
           setShowSpectrogram((v) => !v);
@@ -295,6 +300,12 @@ export default function App() {
           onClick={() => setShowChat((v) => !v)}
         >
           Chat
+        </button>
+        <button
+          className={`btn${showWebhooks ? " active" : ""}`}
+          onClick={() => setShowWebhooks((v) => !v)}
+        >
+          Webhooks
         </button>
         <button
           className="btn btn-xr"
@@ -491,6 +502,14 @@ export default function App() {
       {/* Chat side panel */}
       <ChatPanel eegData={eeg.data} open={showChat} onClose={() => setShowChat(false)} />
 
+      {/* Webhooks side panel */}
+      <WebhookPanel
+        open={showWebhooks}
+        onClose={() => setShowWebhooks(false)}
+        sendCommand={eeg.sendCommand}
+        numChannels={numCh}
+      />
+
       {/* Keyboard shortcut help (press ? to toggle) */}
       <ShortcutHelp />
 
@@ -505,6 +524,7 @@ export default function App() {
           <kbd>S</kbd> Stats
           <kbd>V</kbd> XR
           <kbd>C</kbd> Chat
+          <kbd>W</kbd> Hooks
           <kbd>Esc</kbd> Close
           <kbd>P</kbd> Perf
         </span>

--- a/dashboard/src/components/WebhookPanel.tsx
+++ b/dashboard/src/components/WebhookPanel.tsx
@@ -1,0 +1,355 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  TRIGGER_TYPES,
+  BANDS,
+  type TriggerType,
+  type WebhookRule,
+  type WebhookEvent,
+  type WSWebhookMessage,
+} from "../types";
+
+// ── trigger labels / descriptions ─────────────────────────────────────────
+
+const TRIGGER_LABELS: Record<TriggerType, string> = {
+  band_power_above: "Band power above",
+  band_power_below: "Band power below",
+  amplitude_above: "Amplitude above",
+  amplitude_below: "Amplitude below",
+  band_ratio_above: "Band ratio above",
+  band_ratio_below: "Band ratio below",
+};
+
+const NEEDS_BAND = new Set<TriggerType>([
+  "band_power_above", "band_power_below",
+]);
+const NEEDS_RATIO = new Set<TriggerType>([
+  "band_ratio_above", "band_ratio_below",
+]);
+const NEEDS_CHANNEL = new Set<TriggerType>([
+  "band_power_above", "band_power_below",
+  "amplitude_above", "amplitude_below",
+  "band_ratio_above", "band_ratio_below",
+]);
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  sendCommand: (cmd: Record<string, unknown>) => void;
+  numChannels: number;
+}
+
+export default function WebhookPanel({ open, onClose, sendCommand, numChannels }: Props) {
+  const [rules, setRules] = useState<WebhookRule[]>([]);
+  const [events, setEvents] = useState<WebhookEvent[]>([]);
+  const [editing, setEditing] = useState<WebhookRule | null>(null);
+  const [tab, setTab] = useState<"rules" | "log">("rules");
+  const eventsRef = useRef(events);
+  eventsRef.current = events;
+
+  // Load rules on open
+  useEffect(() => {
+    if (open) sendCommand({ cmd: "webhook_list" });
+  }, [open, sendCommand]);
+
+  // Listen for webhook messages from the WS (attached to global handler)
+  const handleWSMessage = useCallback((msg: WSWebhookMessage) => {
+    if (msg.webhook_rules) setRules(msg.webhook_rules);
+    if (msg.webhook_created) setRules((prev) => [...prev, msg.webhook_created!]);
+    if (msg.webhook_updated) {
+      setRules((prev) =>
+        prev.map((r) => (r.id === msg.webhook_updated!.id ? msg.webhook_updated! : r))
+      );
+    }
+    if (msg.webhook_deleted !== undefined) {
+      // Rule list will be refreshed
+      sendCommand({ cmd: "webhook_list" });
+    }
+    if (msg.webhook_event) {
+      const ev = msg.webhook_event;
+      setEvents((prev) => [ev, ...prev].slice(0, 50));
+    }
+  }, [sendCommand]);
+
+  // Expose handler so parent can wire it
+  useEffect(() => {
+    (window as unknown as Record<string, unknown>).__webhookHandler = handleWSMessage;
+    return () => { delete (window as unknown as Record<string, unknown>).__webhookHandler; };
+  }, [handleWSMessage]);
+
+  if (!open) return null;
+
+  function saveRule(rule: Partial<WebhookRule> & { id?: string }) {
+    if (rule.id && rules.some((r) => r.id === rule.id)) {
+      sendCommand({ cmd: "webhook_update", rule_id: rule.id, rule });
+    } else {
+      sendCommand({ cmd: "webhook_create", rule });
+    }
+    setEditing(null);
+  }
+
+  function deleteRule(id: string) {
+    sendCommand({ cmd: "webhook_delete", rule_id: id });
+  }
+
+  function testRule(id: string) {
+    sendCommand({ cmd: "webhook_test", rule_id: id });
+  }
+
+  function toggleRule(rule: WebhookRule) {
+    sendCommand({
+      cmd: "webhook_update",
+      rule_id: rule.id,
+      rule: { enabled: !rule.enabled },
+    });
+  }
+
+  return (
+    <div className="webhook-panel side-panel">
+      <div className="panel-header">
+        <h2>Webhooks</h2>
+        <button className="btn-close" onClick={onClose}>×</button>
+      </div>
+
+      <div className="webhook-tabs">
+        <button className={`wh-tab${tab === "rules" ? " active" : ""}`} onClick={() => setTab("rules")}>
+          Rules ({rules.length})
+        </button>
+        <button className={`wh-tab${tab === "log" ? " active" : ""}`} onClick={() => setTab("log")}>
+          Log ({events.length})
+        </button>
+      </div>
+
+      {tab === "rules" && (
+        <div className="webhook-rules">
+          {editing ? (
+            <RuleEditor
+              rule={editing}
+              numChannels={numChannels}
+              onSave={saveRule}
+              onCancel={() => setEditing(null)}
+            />
+          ) : (
+            <>
+              <button className="btn btn-add" onClick={() => setEditing(newRule())}>
+                + Add Rule
+              </button>
+              {rules.length === 0 && (
+                <p className="wh-empty">No webhook rules configured. Add one to get started.</p>
+              )}
+              {rules.map((r) => (
+                <div key={r.id} className={`wh-rule-card${r.enabled ? "" : " disabled"}`}>
+                  <div className="wh-rule-header">
+                    <label className="wh-toggle">
+                      <input
+                        type="checkbox"
+                        checked={r.enabled}
+                        onChange={() => toggleRule(r)}
+                      />
+                      <span className="wh-rule-name">{r.name || "Untitled"}</span>
+                    </label>
+                    <div className="wh-rule-actions">
+                      <button className="btn-sm" onClick={() => setEditing(r)} title="Edit">✎</button>
+                      <button className="btn-sm" onClick={() => testRule(r.id)} title="Test">▶</button>
+                      <button className="btn-sm btn-danger" onClick={() => deleteRule(r.id)} title="Delete">✕</button>
+                    </div>
+                  </div>
+                  <div className="wh-rule-detail">
+                    <span className="wh-trigger">{TRIGGER_LABELS[r.trigger_type]}</span>
+                    {r.params.band && <span className="wh-badge">{String(r.params.band)}</span>}
+                    {r.params.threshold !== undefined && (
+                      <span className="wh-badge">≥ {String(r.params.threshold)}</span>
+                    )}
+                    <span className="wh-badge">⏱ {r.cooldown}s</span>
+                    {r.fire_count > 0 && (
+                      <span className="wh-badge wh-fired">🔔 {r.fire_count}×</span>
+                    )}
+                  </div>
+                  <div className="wh-url">{r.url || "No URL"}</div>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      )}
+
+      {tab === "log" && (
+        <div className="webhook-log">
+          {events.length === 0 && <p className="wh-empty">No webhook events yet.</p>}
+          {events.map((ev, i) => (
+            <div key={`${ev.ts}-${i}`} className="wh-log-entry">
+              <span className="wh-log-time">
+                {new Date(ev.ts * 1000).toLocaleTimeString()}
+              </span>
+              <span className="wh-log-name">{ev.rule_name}</span>
+              <span className="wh-log-type">{ev.trigger_type}</span>
+              <span className="wh-log-value">
+                {ev.value.toFixed(2)} (≥{ev.threshold})
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Default new rule ──────────────────────────────────────────────────────
+
+function newRule(): WebhookRule {
+  return {
+    id: "",
+    name: "",
+    enabled: true,
+    trigger_type: "band_power_above",
+    params: { band: "alpha", channel: 0, threshold: 10 },
+    url: "",
+    method: "POST",
+    headers: {},
+    body_template: "",
+    cooldown: 10,
+    last_fired: 0,
+    fire_count: 0,
+  };
+}
+
+// ── Rule editor form ──────────────────────────────────────────────────────
+
+function RuleEditor({
+  rule,
+  numChannels,
+  onSave,
+  onCancel,
+}: {
+  rule: WebhookRule;
+  numChannels: number;
+  onSave: (r: Partial<WebhookRule> & { id?: string }) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(rule.name);
+  const [triggerType, setTriggerType] = useState<TriggerType>(rule.trigger_type);
+  const [band, setBand] = useState(String(rule.params.band || "alpha"));
+  const [numerator, setNumerator] = useState(String(rule.params.numerator || "alpha"));
+  const [denominator, setDenominator] = useState(String(rule.params.denominator || "theta"));
+  const [channel, setChannel] = useState(String(rule.params.channel ?? 0));
+  const [threshold, setThreshold] = useState(String(rule.params.threshold ?? 10));
+  const [url, setUrl] = useState(rule.url);
+  const [cooldown, setCooldown] = useState(String(rule.cooldown));
+  const [bodyTemplate, setBodyTemplate] = useState(rule.body_template);
+
+  function handleSave() {
+    const params: Record<string, unknown> = { threshold: parseFloat(threshold) || 0 };
+    if (NEEDS_BAND.has(triggerType)) params.band = band;
+    if (NEEDS_RATIO.has(triggerType)) {
+      params.numerator = numerator;
+      params.denominator = denominator;
+    }
+    if (NEEDS_CHANNEL.has(triggerType)) {
+      params.channel = channel === "avg" ? "avg" : parseInt(channel) || 0;
+    }
+    if (triggerType === "blink_detected" || triggerType === "jaw_clench") {
+      params.threshold = parseFloat(threshold) || (triggerType === "blink_detected" ? 150 : 120);
+    }
+
+    onSave({
+      ...(rule.id ? { id: rule.id } : {}),
+      name: name || `${TRIGGER_LABELS[triggerType]}`,
+      trigger_type: triggerType,
+      params,
+      url,
+      method: "POST",
+      headers: {},
+      body_template: bodyTemplate,
+      cooldown: parseFloat(cooldown) || 10,
+    });
+  }
+
+  return (
+    <div className="wh-editor">
+      <h3>{rule.id ? "Edit Rule" : "New Rule"}</h3>
+
+      <label>Name</label>
+      <input value={name} onChange={(e) => setName(e.target.value)} placeholder="My webhook" />
+
+      <label>Trigger</label>
+      <select value={triggerType} onChange={(e) => setTriggerType(e.target.value as TriggerType)}>
+        {TRIGGER_TYPES.map((t) => (
+          <option key={t} value={t}>{TRIGGER_LABELS[t]}</option>
+        ))}
+      </select>
+
+      {NEEDS_BAND.has(triggerType) && (
+        <>
+          <label>Band</label>
+          <select value={band} onChange={(e) => setBand(e.target.value)}>
+            {BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </>
+      )}
+
+      {NEEDS_RATIO.has(triggerType) && (
+        <>
+          <label>Numerator band</label>
+          <select value={numerator} onChange={(e) => setNumerator(e.target.value)}>
+            {BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
+          </select>
+          <label>Denominator band</label>
+          <select value={denominator} onChange={(e) => setDenominator(e.target.value)}>
+            {BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </>
+      )}
+
+      {NEEDS_CHANNEL.has(triggerType) && (
+        <>
+          <label>Channel</label>
+          <select value={channel} onChange={(e) => setChannel(e.target.value)}>
+            <option value="avg">Average (all)</option>
+            {Array.from({ length: numChannels }, (_, i) => (
+              <option key={i} value={i}>Ch {i + 1}</option>
+            ))}
+          </select>
+        </>
+      )}
+
+      <label>Threshold</label>
+      <input
+        type="number"
+        value={threshold}
+        step="0.1"
+        onChange={(e) => setThreshold(e.target.value)}
+      />
+
+      <label>Webhook URL</label>
+      <input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="https://example.com/webhook"
+      />
+
+      <label>Cooldown (seconds)</label>
+      <input
+        type="number"
+        value={cooldown}
+        min="1"
+        step="1"
+        onChange={(e) => setCooldown(e.target.value)}
+      />
+
+      <label>Body template (optional)</label>
+      <textarea
+        value={bodyTemplate}
+        onChange={(e) => setBodyTemplate(e.target.value)}
+        placeholder='{"event":"$trigger_type","value":$value}'
+        rows={3}
+      />
+      <small className="wh-hint">
+        Variables: $trigger_type, $rule_name, $value, $threshold, $channel, $band, $ts
+      </small>
+
+      <div className="wh-editor-actions">
+        <button className="btn" onClick={handleSave}>Save</button>
+        <button className="btn btn-muted" onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/WebhookPanel.tsx
+++ b/dashboard/src/components/WebhookPanel.tsx
@@ -233,8 +233,9 @@ function RuleEditor({
   const [channel, setChannel] = useState(String(rule.params.channel ?? 0));
   const [threshold, setThreshold] = useState(String(rule.params.threshold ?? 10));
   const [url, setUrl] = useState(rule.url);
+  const [method, setMethod] = useState(rule.method || "POST");
+  const [authHeader, setAuthHeader] = useState(rule.headers?.Authorization || "");
   const [cooldown, setCooldown] = useState(String(rule.cooldown));
-  const [bodyTemplate, setBodyTemplate] = useState(rule.body_template);
 
   function handleSave() {
     const params: Record<string, unknown> = { threshold: parseFloat(threshold) || 0 };
@@ -246,9 +247,9 @@ function RuleEditor({
     if (NEEDS_CHANNEL.has(triggerType)) {
       params.channel = channel === "avg" ? "avg" : parseInt(channel) || 0;
     }
-    if (triggerType === "blink_detected" || triggerType === "jaw_clench") {
-      params.threshold = parseFloat(threshold) || (triggerType === "blink_detected" ? 150 : 120);
-    }
+
+    const headers: Record<string, string> = {};
+    if (authHeader.trim()) headers.Authorization = authHeader.trim();
 
     onSave({
       ...(rule.id ? { id: rule.id } : {}),
@@ -256,9 +257,8 @@ function RuleEditor({
       trigger_type: triggerType,
       params,
       url,
-      method: "POST",
-      headers: {},
-      body_template: bodyTemplate,
+      method,
+      headers,
       cooldown: parseFloat(cooldown) || 10,
     });
   }
@@ -326,6 +326,21 @@ function RuleEditor({
         placeholder="https://example.com/webhook"
       />
 
+      <label>Method</label>
+      <select value={method} onChange={(e) => setMethod(e.target.value)}>
+        <option value="POST">POST</option>
+        <option value="PUT">PUT</option>
+        <option value="PATCH">PATCH</option>
+        <option value="GET">GET</option>
+      </select>
+
+      <label>Authorization header</label>
+      <input
+        value={authHeader}
+        onChange={(e) => setAuthHeader(e.target.value)}
+        placeholder="Bearer your-token-here"
+      />
+
       <label>Cooldown (seconds)</label>
       <input
         type="number"
@@ -334,17 +349,6 @@ function RuleEditor({
         step="1"
         onChange={(e) => setCooldown(e.target.value)}
       />
-
-      <label>Body template (optional)</label>
-      <textarea
-        value={bodyTemplate}
-        onChange={(e) => setBodyTemplate(e.target.value)}
-        placeholder='{"event":"$trigger_type","value":$value}'
-        rows={3}
-      />
-      <small className="wh-hint">
-        Variables: $trigger_type, $rule_name, $value, $threshold, $channel, $band, $ts
-      </small>
 
       <div className="wh-editor-actions">
         <button className="btn" onClick={handleSave}>Save</button>

--- a/dashboard/src/components/WebhookPanel.tsx
+++ b/dashboard/src/components/WebhookPanel.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState } from "react";
 import {
   TRIGGER_TYPES,
   BANDS,
   type TriggerType,
   type WebhookRule,
   type WebhookEvent,
-  type WSWebhookMessage,
 } from "../types";
+import type { UseWebhooksReturn } from "../hooks/useWebhooks";
 
 // ── trigger labels / descriptions ─────────────────────────────────────────
 
@@ -18,6 +18,12 @@ const TRIGGER_LABELS: Record<TriggerType, string> = {
   band_ratio_above: "Band ratio above",
   band_ratio_below: "Band ratio below",
 };
+
+// ── inline help tooltip ───────────────────────────────────────────────────
+
+function Hint({ text }: { text: string }) {
+  return <span className="wh-hint" title={text}>?</span>;
+}
 
 const NEEDS_BAND = new Set<TriggerType>([
   "band_power_above", "band_power_below",
@@ -34,73 +40,24 @@ const NEEDS_CHANNEL = new Set<TriggerType>([
 interface Props {
   open: boolean;
   onClose: () => void;
-  sendCommand: (cmd: Record<string, unknown>) => void;
   numChannels: number;
+  webhooks: UseWebhooksReturn;
+  webhooksEnabled: boolean;
+  onToggleEnabled: () => void;
 }
 
-export default function WebhookPanel({ open, onClose, sendCommand, numChannels }: Props) {
-  const [rules, setRules] = useState<WebhookRule[]>([]);
-  const [events, setEvents] = useState<WebhookEvent[]>([]);
+export default function WebhookPanel({
+  open, onClose, numChannels, webhooks, webhooksEnabled, onToggleEnabled,
+}: Props) {
+  const { rules, events, saveRule, deleteRule, testRule, toggleRule } = webhooks;
   const [editing, setEditing] = useState<WebhookRule | null>(null);
   const [tab, setTab] = useState<"rules" | "log">("rules");
-  const eventsRef = useRef(events);
-  eventsRef.current = events;
-
-  // Load rules on open
-  useEffect(() => {
-    if (open) sendCommand({ cmd: "webhook_list" });
-  }, [open, sendCommand]);
-
-  // Listen for webhook messages from the WS (attached to global handler)
-  const handleWSMessage = useCallback((msg: WSWebhookMessage) => {
-    if (msg.webhook_rules) setRules(msg.webhook_rules);
-    if (msg.webhook_created) setRules((prev) => [...prev, msg.webhook_created!]);
-    if (msg.webhook_updated) {
-      setRules((prev) =>
-        prev.map((r) => (r.id === msg.webhook_updated!.id ? msg.webhook_updated! : r))
-      );
-    }
-    if (msg.webhook_deleted !== undefined) {
-      // Rule list will be refreshed
-      sendCommand({ cmd: "webhook_list" });
-    }
-    if (msg.webhook_event) {
-      const ev = msg.webhook_event;
-      setEvents((prev) => [ev, ...prev].slice(0, 50));
-    }
-  }, [sendCommand]);
-
-  // Expose handler so parent can wire it
-  useEffect(() => {
-    (window as unknown as Record<string, unknown>).__webhookHandler = handleWSMessage;
-    return () => { delete (window as unknown as Record<string, unknown>).__webhookHandler; };
-  }, [handleWSMessage]);
 
   if (!open) return null;
 
-  function saveRule(rule: Partial<WebhookRule> & { id?: string }) {
-    if (rule.id && rules.some((r) => r.id === rule.id)) {
-      sendCommand({ cmd: "webhook_update", rule_id: rule.id, rule });
-    } else {
-      sendCommand({ cmd: "webhook_create", rule });
-    }
+  function handleSave(rule: Partial<WebhookRule> & { id?: string }) {
+    saveRule(rule);
     setEditing(null);
-  }
-
-  function deleteRule(id: string) {
-    sendCommand({ cmd: "webhook_delete", rule_id: id });
-  }
-
-  function testRule(id: string) {
-    sendCommand({ cmd: "webhook_test", rule_id: id });
-  }
-
-  function toggleRule(rule: WebhookRule) {
-    sendCommand({
-      cmd: "webhook_update",
-      rule_id: rule.id,
-      rule: { enabled: !rule.enabled },
-    });
   }
 
   return (
@@ -110,12 +67,26 @@ export default function WebhookPanel({ open, onClose, sendCommand, numChannels }
         <button className="btn-close" onClick={onClose}>×</button>
       </div>
 
+      <p className="wh-intro">
+        Send HTTP requests when EEG conditions are met.
+        Define rules based on band power, amplitude, or band ratios.
+        Evaluation runs in the browser — close this panel and it keeps working.
+      </p>
+
+      <div className="wh-enable-row">
+        <label className="wh-toggle-main">
+          <input type="checkbox" checked={webhooksEnabled} onChange={onToggleEnabled} />
+          <span>{webhooksEnabled ? "Evaluation active" : "Evaluation paused"}</span>
+          <Hint text="When enabled, rules are evaluated once per second against live EEG data. Disable to pause all triggers without deleting rules." />
+        </label>
+      </div>
+
       <div className="webhook-tabs">
         <button className={`wh-tab${tab === "rules" ? " active" : ""}`} onClick={() => setTab("rules")}>
-          Rules ({rules.length})
+          Rules ({rules.length}) <Hint text="Trigger rules that fire webhooks when EEG conditions are met" />
         </button>
         <button className={`wh-tab${tab === "log" ? " active" : ""}`} onClick={() => setTab("log")}>
-          Log ({events.length})
+          Log ({events.length}) <Hint text="History of recently fired webhook events" />
         </button>
       </div>
 
@@ -125,13 +96,13 @@ export default function WebhookPanel({ open, onClose, sendCommand, numChannels }
             <RuleEditor
               rule={editing}
               numChannels={numChannels}
-              onSave={saveRule}
+              onSave={handleSave}
               onCancel={() => setEditing(null)}
             />
           ) : (
             <>
               <button className="btn btn-add" onClick={() => setEditing(newRule())}>
-                + Add Rule
+                + Add Rule <Hint text="Create a new webhook rule to trigger HTTP requests on EEG events" />
               </button>
               {rules.length === 0 && (
                 <p className="wh-empty">No webhook rules configured. Add one to get started.</p>
@@ -155,7 +126,7 @@ export default function WebhookPanel({ open, onClose, sendCommand, numChannels }
                   </div>
                   <div className="wh-rule-detail">
                     <span className="wh-trigger">{TRIGGER_LABELS[r.trigger_type]}</span>
-                    {r.params.band && <span className="wh-badge">{String(r.params.band)}</span>}
+                    {r.params.band ? <span className="wh-badge">{String(r.params.band)}</span> : null}
                     {r.params.threshold !== undefined && (
                       <span className="wh-badge">≥ {String(r.params.threshold)}</span>
                     )}
@@ -267,10 +238,10 @@ function RuleEditor({
     <div className="wh-editor">
       <h3>{rule.id ? "Edit Rule" : "New Rule"}</h3>
 
-      <label>Name</label>
+      <label>Name <Hint text="A friendly name to identify this rule in the list and logs" /></label>
       <input value={name} onChange={(e) => setName(e.target.value)} placeholder="My webhook" />
 
-      <label>Trigger</label>
+      <label>Trigger <Hint text="The EEG condition to watch for. Evaluated once per second using live FFT data" /></label>
       <select value={triggerType} onChange={(e) => setTriggerType(e.target.value as TriggerType)}>
         {TRIGGER_TYPES.map((t) => (
           <option key={t} value={t}>{TRIGGER_LABELS[t]}</option>
@@ -279,7 +250,7 @@ function RuleEditor({
 
       {NEEDS_BAND.has(triggerType) && (
         <>
-          <label>Band</label>
+          <label>Band <Hint text="EEG frequency band: delta (0.5-4 Hz), theta (4-8), alpha (8-13), beta (13-30), gamma (30-100)" /></label>
           <select value={band} onChange={(e) => setBand(e.target.value)}>
             {BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
           </select>
@@ -288,11 +259,11 @@ function RuleEditor({
 
       {NEEDS_RATIO.has(triggerType) && (
         <>
-          <label>Numerator band</label>
+          <label>Numerator band <Hint text="Top band in the ratio (e.g. alpha in alpha/theta)" /></label>
           <select value={numerator} onChange={(e) => setNumerator(e.target.value)}>
             {BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
           </select>
-          <label>Denominator band</label>
+          <label>Denominator band <Hint text="Bottom band in the ratio (e.g. theta in alpha/theta)" /></label>
           <select value={denominator} onChange={(e) => setDenominator(e.target.value)}>
             {BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
           </select>
@@ -301,7 +272,7 @@ function RuleEditor({
 
       {NEEDS_CHANNEL.has(triggerType) && (
         <>
-          <label>Channel</label>
+          <label>Channel <Hint text="Which EEG channel to monitor, or 'Average' to average all channels" /></label>
           <select value={channel} onChange={(e) => setChannel(e.target.value)}>
             <option value="avg">Average (all)</option>
             {Array.from({ length: numChannels }, (_, i) => (
@@ -311,7 +282,7 @@ function RuleEditor({
         </>
       )}
 
-      <label>Threshold</label>
+      <label>Threshold <Hint text="Value that triggers the webhook. Units depend on trigger type (µV² for band power, µV for amplitude, ratio for band ratio)" /></label>
       <input
         type="number"
         value={threshold}
@@ -319,14 +290,14 @@ function RuleEditor({
         onChange={(e) => setThreshold(e.target.value)}
       />
 
-      <label>Webhook URL</label>
+      <label>Webhook URL <Hint text="The HTTP endpoint that will receive the webhook request when triggered" /></label>
       <input
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         placeholder="https://example.com/webhook"
       />
 
-      <label>Method</label>
+      <label>Method <Hint text="HTTP method to use for the webhook request" /></label>
       <select value={method} onChange={(e) => setMethod(e.target.value)}>
         <option value="POST">POST</option>
         <option value="PUT">PUT</option>
@@ -334,14 +305,14 @@ function RuleEditor({
         <option value="GET">GET</option>
       </select>
 
-      <label>Authorization header</label>
+      <label>Authorization header <Hint text="Optional auth token sent with the request, e.g. 'Bearer abc123'" /></label>
       <input
         value={authHeader}
         onChange={(e) => setAuthHeader(e.target.value)}
         placeholder="Bearer your-token-here"
       />
 
-      <label>Cooldown (seconds)</label>
+      <label>Cooldown (seconds) <Hint text="Minimum time between two consecutive fires of this rule, to avoid spamming" /></label>
       <input
         type="number"
         value={cooldown}

--- a/dashboard/src/hooks/useEEG.ts
+++ b/dashboard/src/hooks/useEEG.ts
@@ -149,6 +149,15 @@ export function useEEG(timeWindowSec = 4): UseEEGReturn {
           }
         }
 
+        // Forward webhook messages to panel handler
+        if ("webhook_rules" in msg || "webhook_created" in msg ||
+            "webhook_updated" in msg || "webhook_deleted" in msg ||
+            "webhook_event" in msg || "webhook_error" in msg ||
+            "webhook_test" in msg) {
+          const handler = (window as unknown as Record<string, unknown>).__webhookHandler;
+          if (typeof handler === "function") handler(msg);
+        }
+
         if ("status" in msg) {
           // Welcome message — read channel count from server
           const serverCh = (msg as Record<string, unknown>).channels;

--- a/dashboard/src/hooks/useWebhookEvaluator.ts
+++ b/dashboard/src/hooks/useWebhookEvaluator.ts
@@ -1,0 +1,179 @@
+/**
+ * Client-side webhook trigger evaluator.
+ *
+ * Uses the existing FftEngine to compute band powers from EEG ring buffers,
+ * evaluates webhook rules locally, and sends `webhook_fire` to the server
+ * when a trigger condition is met. The server then relays the HTTP request.
+ */
+
+import { useEffect, useRef } from "react";
+import { FftEngine } from "../lib/fftEngine";
+import type { EEGData, WebhookRule } from "../types";
+
+const FFT_SIZE = 256;
+const EVAL_INTERVAL_MS = 1000; // evaluate every 1 s
+
+/** Map lowercase band names (from rules) → capitalised (from fftEngine). */
+const BAND_MAP: Record<string, string> = {
+  delta: "Delta",
+  theta: "Theta",
+  alpha: "Alpha",
+  beta: "Beta",
+  gamma: "Gamma",
+};
+
+// Shared engine instance — no need to recreate per hook mount.
+let fftEngine: FftEngine | null = null;
+function getEngine(): FftEngine {
+  if (!fftEngine) fftEngine = new FftEngine(FFT_SIZE, 250);
+  return fftEngine;
+}
+
+/**
+ * Evaluate a single rule against current band powers / amplitude.
+ * Returns [triggered, measuredValue].
+ */
+function evaluateRule(
+  rule: WebhookRule,
+  bandPowers: Record<string, number>,
+  amplitude: number,
+): [boolean, number] {
+  const { trigger_type, params } = rule;
+  const threshold = Number(params.threshold ?? 0);
+
+  if (trigger_type === "band_power_above" || trigger_type === "band_power_below") {
+    const band = BAND_MAP[String(params.band ?? "alpha")] ?? "Alpha";
+    const val = bandPowers[band] ?? 0;
+    return trigger_type === "band_power_above"
+      ? [val > threshold, val]
+      : [val < threshold, val];
+  }
+
+  if (trigger_type === "amplitude_above" || trigger_type === "amplitude_below") {
+    return trigger_type === "amplitude_above"
+      ? [amplitude > threshold, amplitude]
+      : [amplitude < threshold, amplitude];
+  }
+
+  if (trigger_type === "band_ratio_above" || trigger_type === "band_ratio_below") {
+    const numBand = BAND_MAP[String(params.numerator ?? "alpha")] ?? "Alpha";
+    const denBand = BAND_MAP[String(params.denominator ?? "theta")] ?? "Theta";
+    const num = bandPowers[numBand] ?? 0;
+    const den = bandPowers[denBand] ?? 0;
+    const ratio = den < 1e-9 ? 0 : num / den;
+    return trigger_type === "band_ratio_above"
+      ? [ratio > threshold, ratio]
+      : [ratio < threshold, ratio];
+  }
+
+  return [false, 0];
+}
+
+export function useWebhookEvaluator(
+  rules: WebhookRule[],
+  eegData: EEGData,
+  sendCommand: (cmd: Record<string, unknown>) => void,
+) {
+  const rulesRef = useRef(rules);
+  rulesRef.current = rules;
+
+  // Track cooldowns client-side (rule_id → last fire timestamp in ms)
+  const cooldownsRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    const engine = getEngine();
+    const timer = setInterval(() => {
+      const currentRules = rulesRef.current;
+      if (!currentRules.length) return;
+
+      const { buffers, writeIndex, samplesInBuffer, numChannels } = eegData;
+      if (samplesInBuffer.current < FFT_SIZE) return;
+
+      const now = Date.now();
+      const cooldowns = cooldownsRef.current;
+
+      for (const rule of currentRules) {
+        if (!rule.enabled || !rule.url) continue;
+
+        // Client-side cooldown check
+        const lastFired = cooldowns.get(rule.id) ?? 0;
+        if (now - lastFired < rule.cooldown * 1000) continue;
+
+        // Determine which channel to evaluate
+        const chParam = rule.params.channel;
+        const channels: number[] =
+          chParam === "avg"
+            ? Array.from({ length: numChannels }, (_, i) => i)
+            : [Math.min(Number(chParam ?? 0), numChannels - 1)];
+
+        // Compute band powers & amplitude for the needed channel(s)
+        let bandPowers: Record<string, number> = {};
+        let amplitude = 0;
+
+        if (channels.length === 1) {
+          const ch = channels[0];
+          const result = engine.analyseRing(
+            buffers.current[ch],
+            writeIndex.current,
+            samplesInBuffer.current,
+          );
+          if (!result) continue;
+          bandPowers = result.bandPowers;
+          // Peak amplitude from last FFT_SIZE samples
+          const buf = buffers.current[ch];
+          const bLen = buf.length;
+          const start = (writeIndex.current - FFT_SIZE + bLen) % bLen;
+          let maxAmp = 0;
+          for (let i = 0; i < FFT_SIZE; i++) {
+            const v = Math.abs(buf[(start + i) % bLen]);
+            if (v > maxAmp) maxAmp = v;
+          }
+          amplitude = maxAmp;
+        } else {
+          // Average across channels
+          const accum: Record<string, number> = {};
+          let ampSum = 0;
+          let count = 0;
+          for (const ch of channels) {
+            const result = engine.analyseRing(
+              buffers.current[ch],
+              writeIndex.current,
+              samplesInBuffer.current,
+            );
+            if (!result) continue;
+            for (const [k, v] of Object.entries(result.bandPowers)) {
+              accum[k] = (accum[k] ?? 0) + v;
+            }
+            const buf = buffers.current[ch];
+            const bLen = buf.length;
+            const start = (writeIndex.current - FFT_SIZE + bLen) % bLen;
+            let maxAmp = 0;
+            for (let i = 0; i < FFT_SIZE; i++) {
+              const v = Math.abs(buf[(start + i) % bLen]);
+              if (v > maxAmp) maxAmp = v;
+            }
+            ampSum += maxAmp;
+            count++;
+          }
+          if (!count) continue;
+          for (const k of Object.keys(accum)) {
+            bandPowers[k] = accum[k] / count;
+          }
+          amplitude = ampSum / count;
+        }
+
+        const [triggered, value] = evaluateRule(rule, bandPowers, amplitude);
+        if (triggered) {
+          cooldowns.set(rule.id, now);
+          sendCommand({
+            cmd: "webhook_fire",
+            rule_id: rule.id,
+            value,
+          });
+        }
+      }
+    }, EVAL_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [eegData, sendCommand]);
+}

--- a/dashboard/src/hooks/useWebhooks.ts
+++ b/dashboard/src/hooks/useWebhooks.ts
@@ -1,0 +1,86 @@
+/**
+ * Top-level webhook state hook.
+ *
+ * Owns rules, events, WS message handling, and the client-side evaluator.
+ * Lives at App level so evaluation runs regardless of panel open/closed.
+ * Controlled by an `enabled` flag (persisted in localStorage by the caller).
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { EEGData, WebhookRule, WebhookEvent, WSWebhookMessage } from "../types";
+import { useWebhookEvaluator } from "./useWebhookEvaluator";
+
+export interface UseWebhooksReturn {
+  rules: WebhookRule[];
+  events: WebhookEvent[];
+  saveRule: (rule: Partial<WebhookRule> & { id?: string }) => void;
+  deleteRule: (id: string) => void;
+  testRule: (id: string) => void;
+  toggleRule: (rule: WebhookRule) => void;
+}
+
+export function useWebhooks(
+  enabled: boolean,
+  eegData: EEGData,
+  sendCommand: (cmd: Record<string, unknown>) => void,
+): UseWebhooksReturn {
+  const [rules, setRules] = useState<WebhookRule[]>([]);
+  const [events, setEvents] = useState<WebhookEvent[]>([]);
+
+  // Load rules from server when enabled
+  useEffect(() => {
+    if (enabled) sendCommand({ cmd: "webhook_list" });
+  }, [enabled, sendCommand]);
+
+  // Handle WS messages — attached via window global
+  const handleWSMessage = useCallback((msg: WSWebhookMessage) => {
+    if (msg.webhook_rules) setRules(msg.webhook_rules);
+    if (msg.webhook_created) setRules((prev) => [...prev, msg.webhook_created!]);
+    if (msg.webhook_updated) {
+      setRules((prev) =>
+        prev.map((r) => (r.id === msg.webhook_updated!.id ? msg.webhook_updated! : r))
+      );
+    }
+    if (msg.webhook_deleted !== undefined) {
+      sendCommand({ cmd: "webhook_list" });
+    }
+    if (msg.webhook_event) {
+      setEvents((prev) => [msg.webhook_event!, ...prev].slice(0, 50));
+    }
+  }, [sendCommand]);
+
+  useEffect(() => {
+    (window as unknown as Record<string, unknown>).__webhookHandler = handleWSMessage;
+    return () => { delete (window as unknown as Record<string, unknown>).__webhookHandler; };
+  }, [handleWSMessage]);
+
+  // Client-side trigger evaluation — only runs when enabled
+  useWebhookEvaluator(enabled ? rules : [], eegData, sendCommand);
+
+  // CRUD actions
+  const saveRule = useCallback((rule: Partial<WebhookRule> & { id?: string }) => {
+    if (rule.id && rules.some((r) => r.id === rule.id)) {
+      sendCommand({ cmd: "webhook_update", rule_id: rule.id, rule });
+    } else {
+      sendCommand({ cmd: "webhook_create", rule });
+    }
+  }, [rules, sendCommand]);
+
+  const deleteRule = useCallback((id: string) => {
+    sendCommand({ cmd: "webhook_delete", rule_id: id });
+  }, [sendCommand]);
+
+  const testRule = useCallback((id: string) => {
+    sendCommand({ cmd: "webhook_test", rule_id: id });
+  }, [sendCommand]);
+
+  const toggleRule = useCallback((rule: WebhookRule) => {
+    sendCommand({
+      cmd: "webhook_update",
+      rule_id: rule.id,
+      rule: { enabled: !rule.enabled },
+    });
+  }, [sendCommand]);
+
+  return { rules, events, saveRule, deleteRule, testRule, toggleRule };
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -2641,7 +2641,7 @@ body {
 
 /* Rule card */
 .wh-rule-card {
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 10px 12px;
@@ -2763,13 +2763,19 @@ body {
 .wh-editor input,
 .wh-editor select,
 .wh-editor textarea {
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xs);
   color: var(--text);
   font-size: 12px;
   padding: 6px 8px;
   font-family: inherit;
+  color-scheme: dark;
+}
+
+.wh-editor select option {
+  background: var(--surface);
+  color: var(--text);
 }
 
 .wh-editor textarea {
@@ -2811,7 +2817,7 @@ body {
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xs);
   font-size: 11px;

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -2534,3 +2534,311 @@ body {
   background: rgba(0, 112, 243, 0.25);
   color: var(--text);
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Webhook Panel
+   ═══════════════════════════════════════════════════════════════════════ */
+
+.webhook-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 420px;
+  max-width: 92vw;
+  height: 100vh;
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  z-index: 910;
+  box-shadow: -4px 0 32px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.webhook-panel .panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 14px;
+  height: 48px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.webhook-panel .panel-header h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.webhook-panel .btn-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-xs);
+}
+
+.webhook-panel .btn-close:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+/* Tabs */
+.webhook-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.wh-tab {
+  flex: 1;
+  padding: 8px 0;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.wh-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--blue);
+}
+
+.wh-tab:hover {
+  color: var(--text);
+}
+
+/* Rules list */
+.webhook-rules {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wh-empty {
+  color: var(--text-dim);
+  font-size: 12px;
+  text-align: center;
+  padding: 24px 0;
+}
+
+.btn-add {
+  width: 100%;
+  padding: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* Rule card */
+.wh-rule-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  transition: opacity 0.15s;
+}
+
+.wh-rule-card.disabled {
+  opacity: 0.45;
+}
+
+.wh-rule-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.wh-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.wh-toggle input[type="checkbox"] {
+  accent-color: var(--green);
+  width: 14px;
+  height: 14px;
+}
+
+.wh-rule-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.wh-rule-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.btn-sm {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btn-sm:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+.btn-sm.btn-danger:hover {
+  color: var(--red);
+  border-color: var(--red);
+}
+
+.wh-rule-detail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.wh-trigger {
+  font-size: 11px;
+  color: var(--blue);
+  font-weight: 500;
+}
+
+.wh-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+
+.wh-badge.wh-fired {
+  background: rgba(56, 211, 159, 0.12);
+  color: var(--green);
+}
+
+.wh-url {
+  font-size: 10px;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Editor */
+.wh-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.wh-editor h3 {
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+}
+
+.wh-editor label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
+.wh-editor input,
+.wh-editor select,
+.wh-editor textarea {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  color: var(--text);
+  font-size: 12px;
+  padding: 6px 8px;
+  font-family: inherit;
+}
+
+.wh-editor textarea {
+  font-family: var(--mono);
+  font-size: 11px;
+  resize: vertical;
+}
+
+.wh-hint {
+  font-size: 10px;
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+
+.wh-editor-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.btn-muted {
+  background: transparent !important;
+  border: 1px solid var(--border) !important;
+  color: var(--text-dim) !important;
+}
+
+/* Log */
+.webhook-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wh-log-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  font-size: 11px;
+}
+
+.wh-log-time {
+  font-family: var(--mono);
+  color: var(--text-dim);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.wh-log-name {
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.wh-log-type {
+  color: var(--blue);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+.wh-log-value {
+  font-family: var(--mono);
+  color: var(--green);
+  font-size: 10px;
+  margin-left: auto;
+  flex-shrink: 0;
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -2586,6 +2586,80 @@ body {
   color: var(--text);
 }
 
+/* Intro description */
+.wh-intro {
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  margin: 0;
+  padding: 6px 12px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Help hint badge */
+.wh-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  cursor: help;
+  margin-left: 4px;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.wh-hint:hover {
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+/* Active indicator dot on Webhooks button */
+.wh-active-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: #3fb950;
+  border-radius: 50%;
+  margin-left: 5px;
+  vertical-align: middle;
+  animation: wh-pulse 2s ease-in-out infinite;
+}
+
+@keyframes wh-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Enable/disable toggle row */
+.wh-enable-row {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.wh-toggle-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.wh-toggle-main input[type="checkbox"] {
+  accent-color: #3fb950;
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+
 /* Tabs */
 .webhook-tabs {
   display: flex;

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -76,7 +76,57 @@ export interface WSRecordStatusMessage {
   };
 }
 
-export type WSMessage = WSSampleMessage | WSStatusMessage | WSRecordStatusMessage;
+export type WSMessage = WSSampleMessage | WSStatusMessage | WSRecordStatusMessage | WSWebhookMessage;
+
+// ── Webhook types ────────────────────────────────────────────────────────
+
+export const TRIGGER_TYPES = [
+  "band_power_above",
+  "band_power_below",
+  "amplitude_above",
+  "amplitude_below",
+  "band_ratio_above",
+  "band_ratio_below",
+] as const;
+
+export type TriggerType = (typeof TRIGGER_TYPES)[number];
+
+export const BANDS = ["delta", "theta", "alpha", "beta", "gamma"] as const;
+export type Band = (typeof BANDS)[number];
+
+export interface WebhookRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  trigger_type: TriggerType;
+  params: Record<string, unknown>;
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body_template: string;
+  cooldown: number;
+  last_fired: number;
+  fire_count: number;
+}
+
+export interface WebhookEvent {
+  rule_id: string;
+  rule_name: string;
+  trigger_type: string;
+  value: number;
+  threshold: number;
+  ts: number;
+}
+
+export interface WSWebhookMessage {
+  webhook_event?: WebhookEvent;
+  webhook_rules?: WebhookRule[];
+  webhook_created?: WebhookRule;
+  webhook_updated?: WebhookRule;
+  webhook_deleted?: boolean;
+  webhook_error?: string;
+  webhook_test?: { ok: boolean; error?: string };
+}
 
 // ── Recording / playback types ───────────────────────────────────────────
 

--- a/pieeg_server/__main__.py
+++ b/pieeg_server/__main__.py
@@ -193,6 +193,10 @@ def parse_args():
         help="Use synthetic EEG data (no hardware needed, for testing)",
     )
     p.add_argument(
+        "--no-webhooks", action="store_true",
+        help="Disable the webhook engine",
+    )
+    p.add_argument(
         "--record", metavar="FILE",
         help="Record EEG data to CSV while streaming",
     )
@@ -345,6 +349,11 @@ def main():
     if args.filter:
         server.enable_filter(args.lowcut, args.highcut)
         logger.info("Server-side filter: %.1f-%.1f Hz", args.lowcut, args.highcut)
+
+    # --- Webhooks ---
+    if not getattr(args, 'no_webhooks', False):
+        server.enable_webhooks()
+        logger.info("Webhooks enabled")
 
     # --- Dashboard ---
     dashboard = None

--- a/pieeg_server/server.py
+++ b/pieeg_server/server.py
@@ -27,6 +27,7 @@ from .acquisition import AcquisitionLoop
 from .auth import AuthManager
 from .filters import MultichannelFilter
 from .recorder import Recorder
+from .webhooks import WebhookEngine
 
 logger = logging.getLogger("pieeg.server")
 
@@ -53,6 +54,8 @@ class PiEEGServer:
         self._recorder_task: asyncio.Task | None = None
         self._record_start_time: float | None = None
         self._recordings_dir = Path("recordings")
+        self._webhooks: WebhookEngine | None = None
+        self._webhook_task: asyncio.Task | None = None
 
     def enable_filter(self, lowcut: float = 1.0, highcut: float = 40.0):
         self._filter = MultichannelFilter(
@@ -62,8 +65,21 @@ class PiEEGServer:
     def disable_filter(self):
         self._filter = None
 
+    def enable_webhooks(self, rules_path=None):
+        """Create the webhook engine (started when run() is called)."""
+        kwargs = {"acquisition": self._acq,
+                  "num_channels": self._num_channels,
+                  "notify_callback": self._broadcast_webhook_event}
+        if rules_path:
+            kwargs["rules_path"] = rules_path
+        self._webhooks = WebhookEngine(**kwargs)
+        logger.info("Webhooks enabled (%d rules loaded)",
+                    len(self._webhooks.list_rules()))
+
     async def run(self):
         """Start the WebSocket server and the broadcast loop."""
+        if self._webhooks:
+            self._webhook_task = asyncio.create_task(self._webhooks.run())
         async with websockets.serve(
             self._handle_client, self._host, self._port,
             ping_interval=20, ping_timeout=10,
@@ -101,14 +117,14 @@ class PiEEGServer:
 
         try:
             async for message in ws:
-                await self._handle_command(message)
+                await self._handle_command(message, ws)
         except websockets.ConnectionClosed:
             pass
         finally:
             self._clients.discard(ws)
             logger.info("Client disconnected: %s", peer)
 
-    async def _handle_command(self, raw: str):
+    async def _handle_command(self, raw: str, ws=None):
         """Process a client command."""
         try:
             msg = json.loads(raw)
@@ -132,6 +148,16 @@ class PiEEGServer:
             await self._start_recording()
         elif cmd == "stop_record":
             await self._stop_recording()
+        elif cmd == "webhook_list":
+            await self._ws_webhook_list(ws)
+        elif cmd == "webhook_create":
+            await self._ws_webhook_create(ws, msg)
+        elif cmd == "webhook_update":
+            await self._ws_webhook_update(ws, msg)
+        elif cmd == "webhook_delete":
+            await self._ws_webhook_delete(ws, msg)
+        elif cmd == "webhook_test":
+            await self._ws_webhook_test(ws, msg)
 
     async def _start_recording(self):
         """Start recording EEG data to a timestamped CSV file."""
@@ -219,3 +245,55 @@ class PiEEGServer:
                     stale.add(ws)
 
             self._clients -= stale
+
+    # ── Webhook WebSocket handlers ─────────────────────────────
+
+    async def _ws_webhook_list(self, ws):
+        if not self._webhooks:
+            return
+        await ws.send(json.dumps({"webhook_rules": self._webhooks.list_rules()}))
+
+    async def _ws_webhook_create(self, ws, msg):
+        if not self._webhooks:
+            return
+        data = msg.get("rule", {})
+        rule = self._webhooks.create_rule(data)
+        await ws.send(json.dumps({"webhook_created": rule}))
+
+    async def _ws_webhook_update(self, ws, msg):
+        if not self._webhooks:
+            return
+        rule_id = msg.get("rule_id")
+        data = msg.get("rule", {})
+        result = self._webhooks.update_rule(rule_id, data)
+        if result:
+            await ws.send(json.dumps({"webhook_updated": result}))
+        else:
+            await ws.send(json.dumps({"webhook_error": "rule_not_found"}))
+
+    async def _ws_webhook_delete(self, ws, msg):
+        if not self._webhooks:
+            return
+        rule_id = msg.get("rule_id")
+        ok = self._webhooks.delete_rule(rule_id)
+        await ws.send(json.dumps({"webhook_deleted": ok, "rule_id": rule_id}))
+
+    async def _ws_webhook_test(self, ws, msg):
+        if not self._webhooks:
+            return
+        rule_id = msg.get("rule_id")
+        result = await self._webhooks.test_rule(rule_id)
+        await ws.send(json.dumps({"webhook_test": result}))
+
+    async def _broadcast_webhook_event(self, event: dict):
+        """Called by WebhookEngine when a rule fires — relay to all clients."""
+        if not self._clients:
+            return
+        payload = json.dumps(event)
+        stale = set()
+        for ws in list(self._clients):
+            try:
+                await ws.send(payload)
+            except websockets.ConnectionClosed:
+                stale.add(ws)
+        self._clients -= stale

--- a/pieeg_server/server.py
+++ b/pieeg_server/server.py
@@ -27,7 +27,7 @@ from .acquisition import AcquisitionLoop
 from .auth import AuthManager
 from .filters import MultichannelFilter
 from .recorder import Recorder
-from .webhooks import WebhookEngine
+from .webhooks import WebhookStore
 
 logger = logging.getLogger("pieeg.server")
 
@@ -54,8 +54,7 @@ class PiEEGServer:
         self._recorder_task: asyncio.Task | None = None
         self._record_start_time: float | None = None
         self._recordings_dir = Path("recordings")
-        self._webhooks: WebhookEngine | None = None
-        self._webhook_task: asyncio.Task | None = None
+        self._webhooks: WebhookStore | None = None
 
     def enable_filter(self, lowcut: float = 1.0, highcut: float = 40.0):
         self._filter = MultichannelFilter(
@@ -66,20 +65,16 @@ class PiEEGServer:
         self._filter = None
 
     def enable_webhooks(self, rules_path=None):
-        """Create the webhook engine (started when run() is called)."""
-        kwargs = {"acquisition": self._acq,
-                  "num_channels": self._num_channels,
-                  "notify_callback": self._broadcast_webhook_event}
+        """Create the webhook store (rules + HTTP relay)."""
+        kwargs = {}
         if rules_path:
             kwargs["rules_path"] = rules_path
-        self._webhooks = WebhookEngine(**kwargs)
+        self._webhooks = WebhookStore(**kwargs)
         logger.info("Webhooks enabled (%d rules loaded)",
                     len(self._webhooks.list_rules()))
 
     async def run(self):
         """Start the WebSocket server and the broadcast loop."""
-        if self._webhooks:
-            self._webhook_task = asyncio.create_task(self._webhooks.run())
         async with websockets.serve(
             self._handle_client, self._host, self._port,
             ping_interval=20, ping_timeout=10,
@@ -158,6 +153,8 @@ class PiEEGServer:
             await self._ws_webhook_delete(ws, msg)
         elif cmd == "webhook_test":
             await self._ws_webhook_test(ws, msg)
+        elif cmd == "webhook_fire":
+            await self._ws_webhook_fire(ws, msg)
 
     async def _start_recording(self):
         """Start recording EEG data to a timestamped CSV file."""
@@ -285,8 +282,26 @@ class PiEEGServer:
         result = await self._webhooks.test_rule(rule_id)
         await ws.send(json.dumps({"webhook_test": result}))
 
+    async def _ws_webhook_fire(self, ws, msg):
+        """Browser evaluated a trigger — relay the HTTP call."""
+        if not self._webhooks:
+            return
+        rule_id = msg.get("rule_id")
+        value = float(msg.get("value", 0))
+        result = await self._webhooks.fire_rule(rule_id, value)
+        if result.get("ok"):
+            event = {
+                "webhook_event": {
+                    "rule_id": rule_id,
+                    "value": round(value, 4),
+                    "ts": time.time(),
+                }
+            }
+            await self._broadcast_webhook_event(event)
+        await ws.send(json.dumps({"webhook_fire": result}))
+
     async def _broadcast_webhook_event(self, event: dict):
-        """Called by WebhookEngine when a rule fires — relay to all clients."""
+        """Relay webhook events to all connected dashboard clients."""
         if not self._clients:
             return
         payload = json.dumps(event)

--- a/pieeg_server/webhooks.py
+++ b/pieeg_server/webhooks.py
@@ -1,9 +1,9 @@
 """
-Webhook engine for PiEEG: evaluates trigger rules against live EEG data
-and fires HTTP callbacks when conditions are met.
+Webhook rules store and HTTP relay for PiEEG.
 
-Runs as an async task on the server, subscribing to the acquisition queue.
 Rules are persisted to a JSON file on disk.
+Trigger evaluation happens client-side (browser already has FFT);
+the server only stores rules and relays HTTP calls.
 """
 
 import asyncio
@@ -13,26 +13,9 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from string import Template
 from urllib.request import Request, urlopen
 
-import numpy as np
-from scipy import signal as sp_signal
-
 logger = logging.getLogger("pieeg.webhooks")
-
-SAMPLE_RATE = 250
-FFT_SIZE = 256  # ~1 s window at 250 Hz
-EVAL_INTERVAL = 1.0  # evaluate rules every N seconds
-
-# Frequency bands (Hz)
-BANDS = {
-    "delta": (0.5, 4.0),
-    "theta": (4.0, 8.0),
-    "alpha": (8.0, 13.0),
-    "beta": (13.0, 30.0),
-    "gamma": (30.0, 45.0),
-}
 
 TRIGGER_TYPES = [
     "band_power_above",
@@ -44,33 +27,6 @@ TRIGGER_TYPES = [
 ]
 
 DEFAULT_RULES_PATH = Path("webhooks.json")
-
-# Hanning window (precomputed)
-_hanning = np.hanning(FFT_SIZE).astype(np.float64)
-_freqs = np.fft.rfftfreq(FFT_SIZE, d=1.0 / SAMPLE_RATE)
-
-# Precompute band masks to avoid recomputing every eval
-_band_masks = {
-    band: (_freqs >= lo) & (_freqs <= hi)
-    for band, (lo, hi) in BANDS.items()
-}
-
-
-def _band_power(psd: np.ndarray, band: str) -> float:
-    """Compute power in a frequency band from one-sided PSD."""
-    mask = _band_masks[band]
-    if not np.any(mask):
-        return 0.0
-    return float(np.mean(psd[mask]))
-
-
-def _compute_psd(samples: np.ndarray) -> np.ndarray:
-    """Compute one-sided PSD (µV²/Hz) from a 1-D array of FFT_SIZE samples."""
-    windowed = samples * _hanning
-    spectrum = np.fft.rfft(windowed)
-    psd = (np.abs(spectrum) ** 2) / (SAMPLE_RATE * FFT_SIZE)
-    psd[1:-1] *= 2  # double non-DC, non-Nyquist
-    return psd
 
 
 class WebhookRule:
@@ -123,34 +79,20 @@ class WebhookRule:
         return cls(**{k: v for k, v in d.items() if k in cls.__slots__})
 
 
-class WebhookEngine:
+class WebhookStore:
     """
-    Evaluates webhook rules against live EEG data and fires HTTP callbacks.
+    Stores webhook rules on disk and relays HTTP calls.
 
-    Subscribes to the acquisition queue, maintains a per-channel ring buffer,
-    runs FFT every ~1 s, and evaluates all enabled rules.
+    Trigger evaluation is done client-side (browser FFT).
+    The browser sends 'webhook_fire' when a rule triggers,
+    and the server relays the HTTP request.
     """
 
-    def __init__(self, acquisition, num_channels: int = 16,
-                 rules_path: Path | str = DEFAULT_RULES_PATH,
-                 notify_callback=None):
-        self._acq = acquisition
-        self._num_channels = num_channels
+    def __init__(self, rules_path: Path | str = DEFAULT_RULES_PATH):
         self._rules_path = Path(rules_path)
         self._rules: list[WebhookRule] = []
-        self._notify = notify_callback  # async fn(event_dict)
-
-        # Ring buffer: (num_channels, FFT_SIZE)
-        self._buf = np.zeros((num_channels, FFT_SIZE), dtype=np.float64)
-        self._ordered = np.empty(FFT_SIZE, dtype=np.float64)  # reusable scratch
-        self._write_idx = 0
-        self._samples_in_buf = 0
-        self._save_pending = False  # throttle disk writes
-
-        # HTTP executor (bounded to avoid runaway threads)
         self._http_pool = ThreadPoolExecutor(max_workers=2,
                                              thread_name_prefix="webhook-http")
-        self._queue = acquisition.subscribe()
         self._load_rules()
 
     # ── Rule CRUD ──────────────────────────────────────────────
@@ -219,185 +161,58 @@ class WebhookEngine:
         except Exception as e:
             logger.warning("Failed to save webhook rules: %s", e)
 
-    # ── Main loop ──────────────────────────────────────────────
+    # ── HTTP relay (called when browser triggers a rule) ───────
 
-    async def run(self):
-        """Main async loop: ingest frames, periodically evaluate rules."""
-        loop = asyncio.get_event_loop()
-        last_eval = 0.0
-
-        while True:
-            frame = await self._queue.get()
-            channels = frame["channels"]
-
-            # Write into ring buffer
-            idx = self._write_idx % FFT_SIZE
-            for ch in range(min(len(channels), self._num_channels)):
-                self._buf[ch, idx] = channels[ch]
-            self._write_idx += 1
-            self._samples_in_buf = min(self._samples_in_buf + 1, FFT_SIZE)
-
-            # Evaluate rules every EVAL_INTERVAL seconds
-            now = time.monotonic()
-            if now - last_eval < EVAL_INTERVAL:
-                continue
-            last_eval = now
-
-            if self._samples_in_buf < FFT_SIZE:
-                continue  # not enough data yet
-
-            # Determine which channels any rule actually needs
-            needed_channels = set()
-            has_active = False
-            for rule in self._rules:
-                if not rule.enabled:
-                    continue
-                if now - rule.last_fired < rule.cooldown:
-                    continue
-                has_active = True
-                ch = rule.params.get("channel", 0)
-                if ch == "avg":
-                    needed_channels = set(range(self._num_channels))
-                    break
-                needed_channels.add(int(ch))
-
-            if not has_active:
-                continue
-
-            if not needed_channels:
-                needed_channels = set(range(self._num_channels))
-
-            # Compute band powers only for needed channels
-            band_powers = {}
-            amplitudes = {}
-            start = self._write_idx % FFT_SIZE
-            for ch in needed_channels:
-                # Direct slice + concat instead of np.roll (zero-copy)
-                row = self._buf[ch]
-                self._ordered[:FFT_SIZE - start] = row[start:]
-                self._ordered[FFT_SIZE - start:] = row[:start]
-                psd = _compute_psd(self._ordered)
-                bp = {band: _band_power(psd, band) for band in BANDS}
-                band_powers[ch] = bp
-                amplitudes[ch] = float(np.max(np.abs(self._ordered)))
-
-            # Evaluate each rule
-            for rule in self._rules:
-                if not rule.enabled:
-                    continue
-                if now - rule.last_fired < rule.cooldown:
-                    continue
-
-                triggered, value = self._evaluate_rule(
-                    rule, band_powers, amplitudes
-                )
-                if triggered:
-                    rule.last_fired = now
-                    rule.fire_count += 1
-                    self._save_pending = True
-
-                    event = {
-                        "webhook_event": {
-                            "rule_id": rule.id,
-                            "rule_name": rule.name,
-                            "trigger_type": rule.trigger_type,
-                            "value": round(value, 4),
-                            "threshold": rule.params.get("threshold", 0),
-                            "ts": time.time(),
-                        }
-                    }
-                    logger.info("Webhook fired: %s (value=%.2f)", rule.name, value)
-
-                    # Notify dashboard
-                    if self._notify:
-                        try:
-                            await self._notify(event)
-                        except Exception:
-                            pass
-
-                    # Fire HTTP in background thread
-                    if rule.url:
-                        loop.run_in_executor(
-                            self._http_pool,
-                            self._fire_http, rule, value
-                        )
-
-            # Batch-save to disk once per eval cycle (not per rule fire)
-            if self._save_pending:
-                self._save_pending = False
+    async def fire_rule(self, rule_id: str, value: float = 0.0) -> dict:
+        """
+        Fire a webhook for a rule. Called by the browser when a trigger
+        condition is met client-side. The server relays the HTTP request.
+        """
+        for r in self._rules:
+            if r.id == rule_id:
+                if not r.url:
+                    return {"ok": False, "error": "no_url"}
+                # Cooldown check (server-side enforcement)
+                now = time.monotonic()
+                if now - r.last_fired < r.cooldown:
+                    return {"ok": False, "error": "cooldown"}
+                r.last_fired = now
+                r.fire_count += 1
                 self._save_rules()
+                loop = asyncio.get_event_loop()
+                loop.run_in_executor(
+                    self._http_pool, self._send_http, r, value
+                )
+                return {"ok": True, "rule_id": rule_id}
+        return {"ok": False, "error": "rule_not_found"}
 
-    # ── Rule evaluation ────────────────────────────────────────
+    async def test_rule(self, rule_id: str) -> dict:
+        """Fire a test webhook (ignores cooldown)."""
+        for r in self._rules:
+            if r.id == rule_id:
+                if not r.url:
+                    return {"ok": False, "error": "no_url"}
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(
+                    self._http_pool, self._send_http, r, 0.0
+                )
+                return {"ok": True, "rule_id": rule_id}
+        return {"ok": False, "error": "rule_not_found"}
 
-    def _evaluate_rule(self, rule: WebhookRule,
-                       band_powers: dict, amplitudes: dict) -> tuple[bool, float]:
-        """Returns (triggered: bool, measured_value: float)."""
-        tt = rule.trigger_type
-        p = rule.params
-        ch = p.get("channel", 0)
-        threshold = p.get("threshold", 0.0)
-
-        if tt == "band_power_above":
-            band = p.get("band", "alpha")
-            val = self._get_band_value(band_powers, band, ch)
-            return val > threshold, val
-
-        elif tt == "band_power_below":
-            band = p.get("band", "alpha")
-            val = self._get_band_value(band_powers, band, ch)
-            return val < threshold, val
-
-        elif tt == "amplitude_above":
-            val = self._get_amplitude(amplitudes, ch)
-            return val > threshold, val
-
-        elif tt == "amplitude_below":
-            val = self._get_amplitude(amplitudes, ch)
-            return val < threshold, val
-
-        elif tt == "band_ratio_above":
-            num_band = p.get("numerator", "alpha")
-            den_band = p.get("denominator", "theta")
-            val = self._get_ratio(band_powers, num_band, den_band, ch)
-            return val > threshold, val
-
-        elif tt == "band_ratio_below":
-            num_band = p.get("numerator", "alpha")
-            den_band = p.get("denominator", "theta")
-            val = self._get_ratio(band_powers, num_band, den_band, ch)
-            return val < threshold, val
-
-        return False, 0.0
-
-    def _get_band_value(self, band_powers: dict, band: str, ch) -> float:
-        if ch == "avg":
-            vals = [band_powers[c].get(band, 0)
-                    for c in range(self._num_channels)]
-            return sum(vals) / len(vals) if vals else 0.0
-        return band_powers.get(int(ch), {}).get(band, 0.0)
-
-    def _get_amplitude(self, amplitudes: dict, ch) -> float:
-        if ch == "avg":
-            vals = [amplitudes.get(c, 0) for c in range(self._num_channels)]
-            return sum(vals) / len(vals) if vals else 0.0
-        return amplitudes.get(int(ch), 0.0)
-
-    def _get_ratio(self, band_powers: dict, num: str, den: str, ch) -> float:
-        num_val = self._get_band_value(band_powers, num, ch)
-        den_val = self._get_band_value(band_powers, den, ch)
-        if den_val < 1e-9:
-            return 0.0
-        return num_val / den_val
-
-    # ── HTTP delivery ──────────────────────────────────────────
-
-    def _fire_http(self, rule: WebhookRule, value: float):
+    def _send_http(self, rule: WebhookRule, value: float):
         """Send webhook HTTP request (runs in thread pool)."""
         try:
-            body = self._render_body(rule, value)
+            body = json.dumps({
+                "event": rule.trigger_type,
+                "rule": rule.name,
+                "value": round(value, 4),
+                "threshold": rule.params.get("threshold", 0),
+                "channel": rule.params.get("channel", 0),
+                "timestamp": time.time(),
+            })
             req = Request(
                 rule.url,
-                data=body.encode("utf-8") if body else None,
+                data=body.encode("utf-8"),
                 method=rule.method,
             )
             req.add_header("Content-Type", "application/json")
@@ -409,43 +224,6 @@ class WebhookEngine:
         except Exception as e:
             logger.warning("Webhook delivery failed (%s): %s", rule.url, e)
 
-    def _render_body(self, rule: WebhookRule, value: float) -> str:
-        """Render the body template with trigger variables."""
-        if rule.body_template:
-            tpl = Template(rule.body_template)
-            return tpl.safe_substitute(
-                trigger_type=rule.trigger_type,
-                rule_name=rule.name,
-                value=round(value, 4),
-                threshold=rule.params.get("threshold", 0),
-                channel=rule.params.get("channel", 0),
-                band=rule.params.get("band", ""),
-                ts=time.time(),
-            )
-        # Default JSON body
-        return json.dumps({
-            "event": rule.trigger_type,
-            "rule": rule.name,
-            "value": round(value, 4),
-            "threshold": rule.params.get("threshold", 0),
-            "channel": rule.params.get("channel", 0),
-            "timestamp": time.time(),
-        })
-
-    # ── Test ───────────────────────────────────────────────────
-
-    async def test_rule(self, rule_id: str) -> dict:
-        """Fire a test webhook for a rule (ignores cooldown)."""
-        for r in self._rules:
-            if r.id == rule_id:
-                loop = asyncio.get_event_loop()
-                await loop.run_in_executor(
-                    self._http_pool, self._fire_http, r, 0.0
-                )
-                return {"ok": True, "rule_id": rule_id}
-        return {"ok": False, "error": "rule_not_found"}
-
     def stop(self):
         """Cleanup."""
         self._http_pool.shutdown(wait=False)
-        self._acq.unsubscribe(self._queue)

--- a/pieeg_server/webhooks.py
+++ b/pieeg_server/webhooks.py
@@ -49,11 +49,16 @@ DEFAULT_RULES_PATH = Path("webhooks.json")
 _hanning = np.hanning(FFT_SIZE).astype(np.float64)
 _freqs = np.fft.rfftfreq(FFT_SIZE, d=1.0 / SAMPLE_RATE)
 
+# Precompute band masks to avoid recomputing every eval
+_band_masks = {
+    band: (_freqs >= lo) & (_freqs <= hi)
+    for band, (lo, hi) in BANDS.items()
+}
+
 
 def _band_power(psd: np.ndarray, band: str) -> float:
     """Compute power in a frequency band from one-sided PSD."""
-    lo, hi = BANDS[band]
-    mask = (_freqs >= lo) & (_freqs <= hi)
+    mask = _band_masks[band]
     if not np.any(mask):
         return 0.0
     return float(np.mean(psd[mask]))
@@ -137,8 +142,10 @@ class WebhookEngine:
 
         # Ring buffer: (num_channels, FFT_SIZE)
         self._buf = np.zeros((num_channels, FFT_SIZE), dtype=np.float64)
+        self._ordered = np.empty(FFT_SIZE, dtype=np.float64)  # reusable scratch
         self._write_idx = 0
         self._samples_in_buf = 0
+        self._save_pending = False  # throttle disk writes
 
         # HTTP executor (bounded to avoid runaway threads)
         self._http_pool = ThreadPoolExecutor(max_workers=2,
@@ -239,17 +246,40 @@ class WebhookEngine:
             if self._samples_in_buf < FFT_SIZE:
                 continue  # not enough data yet
 
-            # Compute band powers for all channels
-            band_powers = {}  # {ch: {band: power}}
-            amplitudes = {}  # {ch: max_abs_amplitude}
-            for ch in range(self._num_channels):
-                # Extract ordered window from ring buffer
-                start = self._write_idx % FFT_SIZE
-                ordered = np.roll(self._buf[ch], -start)
-                psd = _compute_psd(ordered)
+            # Determine which channels any rule actually needs
+            needed_channels = set()
+            has_active = False
+            for rule in self._rules:
+                if not rule.enabled:
+                    continue
+                if now - rule.last_fired < rule.cooldown:
+                    continue
+                has_active = True
+                ch = rule.params.get("channel", 0)
+                if ch == "avg":
+                    needed_channels = set(range(self._num_channels))
+                    break
+                needed_channels.add(int(ch))
+
+            if not has_active:
+                continue
+
+            if not needed_channels:
+                needed_channels = set(range(self._num_channels))
+
+            # Compute band powers only for needed channels
+            band_powers = {}
+            amplitudes = {}
+            start = self._write_idx % FFT_SIZE
+            for ch in needed_channels:
+                # Direct slice + concat instead of np.roll (zero-copy)
+                row = self._buf[ch]
+                self._ordered[:FFT_SIZE - start] = row[start:]
+                self._ordered[FFT_SIZE - start:] = row[:start]
+                psd = _compute_psd(self._ordered)
                 bp = {band: _band_power(psd, band) for band in BANDS}
                 band_powers[ch] = bp
-                amplitudes[ch] = float(np.max(np.abs(ordered)))
+                amplitudes[ch] = float(np.max(np.abs(self._ordered)))
 
             # Evaluate each rule
             for rule in self._rules:
@@ -264,7 +294,7 @@ class WebhookEngine:
                 if triggered:
                     rule.last_fired = now
                     rule.fire_count += 1
-                    self._save_rules()
+                    self._save_pending = True
 
                     event = {
                         "webhook_event": {
@@ -291,6 +321,11 @@ class WebhookEngine:
                             self._http_pool,
                             self._fire_http, rule, value
                         )
+
+            # Batch-save to disk once per eval cycle (not per rule fire)
+            if self._save_pending:
+                self._save_pending = False
+                self._save_rules()
 
     # ── Rule evaluation ────────────────────────────────────────
 

--- a/pieeg_server/webhooks.py
+++ b/pieeg_server/webhooks.py
@@ -1,0 +1,416 @@
+"""
+Webhook engine for PiEEG: evaluates trigger rules against live EEG data
+and fires HTTP callbacks when conditions are met.
+
+Runs as an async task on the server, subscribing to the acquisition queue.
+Rules are persisted to a JSON file on disk.
+"""
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from string import Template
+from urllib.request import Request, urlopen
+
+import numpy as np
+from scipy import signal as sp_signal
+
+logger = logging.getLogger("pieeg.webhooks")
+
+SAMPLE_RATE = 250
+FFT_SIZE = 256  # ~1 s window at 250 Hz
+EVAL_INTERVAL = 1.0  # evaluate rules every N seconds
+
+# Frequency bands (Hz)
+BANDS = {
+    "delta": (0.5, 4.0),
+    "theta": (4.0, 8.0),
+    "alpha": (8.0, 13.0),
+    "beta": (13.0, 30.0),
+    "gamma": (30.0, 45.0),
+}
+
+TRIGGER_TYPES = [
+    "band_power_above",
+    "band_power_below",
+    "amplitude_above",
+    "amplitude_below",
+    "band_ratio_above",
+    "band_ratio_below",
+]
+
+DEFAULT_RULES_PATH = Path("webhooks.json")
+
+# Hanning window (precomputed)
+_hanning = np.hanning(FFT_SIZE).astype(np.float64)
+_freqs = np.fft.rfftfreq(FFT_SIZE, d=1.0 / SAMPLE_RATE)
+
+
+def _band_power(psd: np.ndarray, band: str) -> float:
+    """Compute power in a frequency band from one-sided PSD."""
+    lo, hi = BANDS[band]
+    mask = (_freqs >= lo) & (_freqs <= hi)
+    if not np.any(mask):
+        return 0.0
+    return float(np.mean(psd[mask]))
+
+
+def _compute_psd(samples: np.ndarray) -> np.ndarray:
+    """Compute one-sided PSD (µV²/Hz) from a 1-D array of FFT_SIZE samples."""
+    windowed = samples * _hanning
+    spectrum = np.fft.rfft(windowed)
+    psd = (np.abs(spectrum) ** 2) / (SAMPLE_RATE * FFT_SIZE)
+    psd[1:-1] *= 2  # double non-DC, non-Nyquist
+    return psd
+
+
+class WebhookRule:
+    """A single webhook trigger rule."""
+
+    __slots__ = (
+        "id", "name", "enabled", "trigger_type", "params",
+        "url", "method", "headers", "body_template",
+        "cooldown", "last_fired", "fire_count",
+    )
+
+    def __init__(self, *, id: str | None = None, name: str = "",
+                 enabled: bool = True, trigger_type: str = "band_power_above",
+                 params: dict | None = None,
+                 url: str = "", method: str = "POST",
+                 headers: dict | None = None, body_template: str = "",
+                 cooldown: float = 10.0, last_fired: float = 0.0,
+                 fire_count: int = 0):
+        self.id = id or str(uuid.uuid4())[:8]
+        self.name = name
+        self.enabled = enabled
+        self.trigger_type = trigger_type
+        self.params = params or {}
+        self.url = url
+        self.method = method
+        self.headers = headers or {}
+        self.body_template = body_template
+        self.cooldown = cooldown
+        self.last_fired = last_fired
+        self.fire_count = fire_count
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "enabled": self.enabled,
+            "trigger_type": self.trigger_type,
+            "params": self.params,
+            "url": self.url,
+            "method": self.method,
+            "headers": self.headers,
+            "body_template": self.body_template,
+            "cooldown": self.cooldown,
+            "last_fired": self.last_fired,
+            "fire_count": self.fire_count,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WebhookRule":
+        return cls(**{k: v for k, v in d.items() if k in cls.__slots__})
+
+
+class WebhookEngine:
+    """
+    Evaluates webhook rules against live EEG data and fires HTTP callbacks.
+
+    Subscribes to the acquisition queue, maintains a per-channel ring buffer,
+    runs FFT every ~1 s, and evaluates all enabled rules.
+    """
+
+    def __init__(self, acquisition, num_channels: int = 16,
+                 rules_path: Path | str = DEFAULT_RULES_PATH,
+                 notify_callback=None):
+        self._acq = acquisition
+        self._num_channels = num_channels
+        self._rules_path = Path(rules_path)
+        self._rules: list[WebhookRule] = []
+        self._notify = notify_callback  # async fn(event_dict)
+
+        # Ring buffer: (num_channels, FFT_SIZE)
+        self._buf = np.zeros((num_channels, FFT_SIZE), dtype=np.float64)
+        self._write_idx = 0
+        self._samples_in_buf = 0
+
+        # HTTP executor (bounded to avoid runaway threads)
+        self._http_pool = ThreadPoolExecutor(max_workers=2,
+                                             thread_name_prefix="webhook-http")
+        self._queue = acquisition.subscribe()
+        self._load_rules()
+
+    # ── Rule CRUD ──────────────────────────────────────────────
+
+    def list_rules(self) -> list[dict]:
+        return [r.to_dict() for r in self._rules]
+
+    def get_rule(self, rule_id: str) -> dict | None:
+        for r in self._rules:
+            if r.id == rule_id:
+                return r.to_dict()
+        return None
+
+    def create_rule(self, data: dict) -> dict:
+        data.pop("id", None)
+        data.pop("last_fired", None)
+        data.pop("fire_count", None)
+        rule = WebhookRule(**data)
+        self._rules.append(rule)
+        self._save_rules()
+        logger.info("Rule created: %s (%s)", rule.name, rule.id)
+        return rule.to_dict()
+
+    def update_rule(self, rule_id: str, data: dict) -> dict | None:
+        for r in self._rules:
+            if r.id == rule_id:
+                for key in ("name", "enabled", "trigger_type", "params",
+                            "url", "method", "headers", "body_template",
+                            "cooldown"):
+                    if key in data:
+                        setattr(r, key, data[key])
+                self._save_rules()
+                logger.info("Rule updated: %s (%s)", r.name, r.id)
+                return r.to_dict()
+        return None
+
+    def delete_rule(self, rule_id: str) -> bool:
+        for i, r in enumerate(self._rules):
+            if r.id == rule_id:
+                self._rules.pop(i)
+                self._save_rules()
+                logger.info("Rule deleted: %s", rule_id)
+                return True
+        return False
+
+    # ── Persistence ────────────────────────────────────────────
+
+    def _load_rules(self):
+        if self._rules_path.exists():
+            try:
+                data = json.loads(self._rules_path.read_text())
+                self._rules = [WebhookRule.from_dict(d) for d in data]
+                logger.info("Loaded %d webhook rules from %s",
+                            len(self._rules), self._rules_path)
+            except Exception as e:
+                logger.warning("Failed to load webhook rules: %s", e)
+                self._rules = []
+        else:
+            self._rules = []
+
+    def _save_rules(self):
+        try:
+            self._rules_path.write_text(
+                json.dumps([r.to_dict() for r in self._rules], indent=2)
+            )
+        except Exception as e:
+            logger.warning("Failed to save webhook rules: %s", e)
+
+    # ── Main loop ──────────────────────────────────────────────
+
+    async def run(self):
+        """Main async loop: ingest frames, periodically evaluate rules."""
+        loop = asyncio.get_event_loop()
+        last_eval = 0.0
+
+        while True:
+            frame = await self._queue.get()
+            channels = frame["channels"]
+
+            # Write into ring buffer
+            idx = self._write_idx % FFT_SIZE
+            for ch in range(min(len(channels), self._num_channels)):
+                self._buf[ch, idx] = channels[ch]
+            self._write_idx += 1
+            self._samples_in_buf = min(self._samples_in_buf + 1, FFT_SIZE)
+
+            # Evaluate rules every EVAL_INTERVAL seconds
+            now = time.monotonic()
+            if now - last_eval < EVAL_INTERVAL:
+                continue
+            last_eval = now
+
+            if self._samples_in_buf < FFT_SIZE:
+                continue  # not enough data yet
+
+            # Compute band powers for all channels
+            band_powers = {}  # {ch: {band: power}}
+            amplitudes = {}  # {ch: max_abs_amplitude}
+            for ch in range(self._num_channels):
+                # Extract ordered window from ring buffer
+                start = self._write_idx % FFT_SIZE
+                ordered = np.roll(self._buf[ch], -start)
+                psd = _compute_psd(ordered)
+                bp = {band: _band_power(psd, band) for band in BANDS}
+                band_powers[ch] = bp
+                amplitudes[ch] = float(np.max(np.abs(ordered)))
+
+            # Evaluate each rule
+            for rule in self._rules:
+                if not rule.enabled:
+                    continue
+                if now - rule.last_fired < rule.cooldown:
+                    continue
+
+                triggered, value = self._evaluate_rule(
+                    rule, band_powers, amplitudes
+                )
+                if triggered:
+                    rule.last_fired = now
+                    rule.fire_count += 1
+                    self._save_rules()
+
+                    event = {
+                        "webhook_event": {
+                            "rule_id": rule.id,
+                            "rule_name": rule.name,
+                            "trigger_type": rule.trigger_type,
+                            "value": round(value, 4),
+                            "threshold": rule.params.get("threshold", 0),
+                            "ts": time.time(),
+                        }
+                    }
+                    logger.info("Webhook fired: %s (value=%.2f)", rule.name, value)
+
+                    # Notify dashboard
+                    if self._notify:
+                        try:
+                            await self._notify(event)
+                        except Exception:
+                            pass
+
+                    # Fire HTTP in background thread
+                    if rule.url:
+                        loop.run_in_executor(
+                            self._http_pool,
+                            self._fire_http, rule, value
+                        )
+
+    # ── Rule evaluation ────────────────────────────────────────
+
+    def _evaluate_rule(self, rule: WebhookRule,
+                       band_powers: dict, amplitudes: dict) -> tuple[bool, float]:
+        """Returns (triggered: bool, measured_value: float)."""
+        tt = rule.trigger_type
+        p = rule.params
+        ch = p.get("channel", 0)
+        threshold = p.get("threshold", 0.0)
+
+        if tt == "band_power_above":
+            band = p.get("band", "alpha")
+            val = self._get_band_value(band_powers, band, ch)
+            return val > threshold, val
+
+        elif tt == "band_power_below":
+            band = p.get("band", "alpha")
+            val = self._get_band_value(band_powers, band, ch)
+            return val < threshold, val
+
+        elif tt == "amplitude_above":
+            val = self._get_amplitude(amplitudes, ch)
+            return val > threshold, val
+
+        elif tt == "amplitude_below":
+            val = self._get_amplitude(amplitudes, ch)
+            return val < threshold, val
+
+        elif tt == "band_ratio_above":
+            num_band = p.get("numerator", "alpha")
+            den_band = p.get("denominator", "theta")
+            val = self._get_ratio(band_powers, num_band, den_band, ch)
+            return val > threshold, val
+
+        elif tt == "band_ratio_below":
+            num_band = p.get("numerator", "alpha")
+            den_band = p.get("denominator", "theta")
+            val = self._get_ratio(band_powers, num_band, den_band, ch)
+            return val < threshold, val
+
+        return False, 0.0
+
+    def _get_band_value(self, band_powers: dict, band: str, ch) -> float:
+        if ch == "avg":
+            vals = [band_powers[c].get(band, 0)
+                    for c in range(self._num_channels)]
+            return sum(vals) / len(vals) if vals else 0.0
+        return band_powers.get(int(ch), {}).get(band, 0.0)
+
+    def _get_amplitude(self, amplitudes: dict, ch) -> float:
+        if ch == "avg":
+            vals = [amplitudes.get(c, 0) for c in range(self._num_channels)]
+            return sum(vals) / len(vals) if vals else 0.0
+        return amplitudes.get(int(ch), 0.0)
+
+    def _get_ratio(self, band_powers: dict, num: str, den: str, ch) -> float:
+        num_val = self._get_band_value(band_powers, num, ch)
+        den_val = self._get_band_value(band_powers, den, ch)
+        if den_val < 1e-9:
+            return 0.0
+        return num_val / den_val
+
+    # ── HTTP delivery ──────────────────────────────────────────
+
+    def _fire_http(self, rule: WebhookRule, value: float):
+        """Send webhook HTTP request (runs in thread pool)."""
+        try:
+            body = self._render_body(rule, value)
+            req = Request(
+                rule.url,
+                data=body.encode("utf-8") if body else None,
+                method=rule.method,
+            )
+            req.add_header("Content-Type", "application/json")
+            req.add_header("User-Agent", "PiEEG-Webhook/1.0")
+            for k, v in rule.headers.items():
+                req.add_header(k, v)
+            with urlopen(req, timeout=10) as resp:
+                logger.debug("Webhook %s → %d", rule.url, resp.status)
+        except Exception as e:
+            logger.warning("Webhook delivery failed (%s): %s", rule.url, e)
+
+    def _render_body(self, rule: WebhookRule, value: float) -> str:
+        """Render the body template with trigger variables."""
+        if rule.body_template:
+            tpl = Template(rule.body_template)
+            return tpl.safe_substitute(
+                trigger_type=rule.trigger_type,
+                rule_name=rule.name,
+                value=round(value, 4),
+                threshold=rule.params.get("threshold", 0),
+                channel=rule.params.get("channel", 0),
+                band=rule.params.get("band", ""),
+                ts=time.time(),
+            )
+        # Default JSON body
+        return json.dumps({
+            "event": rule.trigger_type,
+            "rule": rule.name,
+            "value": round(value, 4),
+            "threshold": rule.params.get("threshold", 0),
+            "channel": rule.params.get("channel", 0),
+            "timestamp": time.time(),
+        })
+
+    # ── Test ───────────────────────────────────────────────────
+
+    async def test_rule(self, rule_id: str) -> dict:
+        """Fire a test webhook for a rule (ignores cooldown)."""
+        for r in self._rules:
+            if r.id == rule_id:
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(
+                    self._http_pool, self._fire_http, r, 0.0
+                )
+                return {"ok": True, "rule_id": rule_id}
+        return {"ok": False, "error": "rule_not_found"}
+
+    def stop(self):
+        """Cleanup."""
+        self._http_pool.shutdown(wait=False)
+        self._acq.unsubscribe(self._queue)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,26 +1,16 @@
 """
-Tests for the webhook engine — rule CRUD, trigger evaluation, persistence.
+Tests for the webhook store — rule CRUD, persistence, HTTP relay.
 """
 
 import asyncio
 import json
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
-from pieeg_server.webhooks import (
-    WebhookEngine,
-    WebhookRule,
-    _band_power,
-    _compute_psd,
-    _freqs,
-    BANDS,
-    FFT_SIZE,
-    SAMPLE_RATE,
-)
+from pieeg_server.webhooks import WebhookStore, WebhookRule
 
 
 # ── Fixtures ───────────────────────────────────────────────────────────────
@@ -31,17 +21,8 @@ def tmp_rules(tmp_path):
 
 
 @pytest.fixture
-def mock_acq():
-    """Minimal acquisition mock with subscribe/unsubscribe."""
-    acq = MagicMock()
-    acq.subscribe.return_value = asyncio.Queue(maxsize=2048)
-    acq.unsubscribe = MagicMock()
-    return acq
-
-
-@pytest.fixture
-def engine(mock_acq, tmp_rules):
-    return WebhookEngine(mock_acq, num_channels=16, rules_path=tmp_rules)
+def store(tmp_rules):
+    return WebhookStore(rules_path=tmp_rules)
 
 
 # ── WebhookRule unit tests ─────────────────────────────────────────────────
@@ -74,8 +55,8 @@ class TestWebhookRule:
 # ── Rule CRUD ──────────────────────────────────────────────────────────────
 
 class TestRuleCRUD:
-    def test_create_and_list(self, engine):
-        result = engine.create_rule({
+    def test_create_and_list(self, store):
+        result = store.create_rule({
             "name": "Test1",
             "trigger_type": "band_power_above",
             "params": {"band": "alpha", "threshold": 15},
@@ -84,190 +65,60 @@ class TestRuleCRUD:
         })
         assert result["name"] == "Test1"
         assert result["id"]
-        rules = engine.list_rules()
+        rules = store.list_rules()
         assert len(rules) == 1
         assert rules[0]["id"] == result["id"]
 
-    def test_update(self, engine):
-        r = engine.create_rule({"name": "Rule1", "url": "https://a.com"})
-        updated = engine.update_rule(r["id"], {"name": "Updated"})
+    def test_update(self, store):
+        r = store.create_rule({"name": "Rule1", "url": "https://a.com"})
+        updated = store.update_rule(r["id"], {"name": "Updated"})
         assert updated["name"] == "Updated"
         assert updated["url"] == "https://a.com"
 
-    def test_update_nonexistent(self, engine):
-        assert engine.update_rule("nope", {"name": "x"}) is None
+    def test_update_nonexistent(self, store):
+        assert store.update_rule("nope", {"name": "x"}) is None
 
-    def test_delete(self, engine):
-        r = engine.create_rule({"name": "ToDelete"})
-        assert engine.delete_rule(r["id"]) is True
-        assert len(engine.list_rules()) == 0
+    def test_delete(self, store):
+        r = store.create_rule({"name": "ToDelete"})
+        assert store.delete_rule(r["id"]) is True
+        assert len(store.list_rules()) == 0
 
-    def test_delete_nonexistent(self, engine):
-        assert engine.delete_rule("nope") is False
+    def test_delete_nonexistent(self, store):
+        assert store.delete_rule("nope") is False
 
-    def test_get_rule(self, engine):
-        r = engine.create_rule({"name": "Find me"})
-        found = engine.get_rule(r["id"])
+    def test_get_rule(self, store):
+        r = store.create_rule({"name": "Find me"})
+        found = store.get_rule(r["id"])
         assert found["name"] == "Find me"
 
-    def test_get_rule_nonexistent(self, engine):
-        assert engine.get_rule("nope") is None
+    def test_get_rule_nonexistent(self, store):
+        assert store.get_rule("nope") is None
 
 
 # ── Persistence ────────────────────────────────────────────────────────────
 
 class TestPersistence:
-    def test_save_and_reload(self, mock_acq, tmp_rules):
-        eng1 = WebhookEngine(mock_acq, rules_path=tmp_rules)
-        eng1.create_rule({"name": "Persistent", "url": "https://a.com"})
+    def test_save_and_reload(self, tmp_rules):
+        s1 = WebhookStore(rules_path=tmp_rules)
+        s1.create_rule({"name": "Persistent", "url": "https://a.com"})
         assert tmp_rules.exists()
 
-        eng2 = WebhookEngine(mock_acq, rules_path=tmp_rules)
-        rules = eng2.list_rules()
+        s2 = WebhookStore(rules_path=tmp_rules)
+        rules = s2.list_rules()
         assert len(rules) == 1
         assert rules[0]["name"] == "Persistent"
 
-    def test_corrupt_file_fallback(self, mock_acq, tmp_rules):
+    def test_corrupt_file_fallback(self, tmp_rules):
         tmp_rules.write_text("NOT JSON")
-        eng = WebhookEngine(mock_acq, rules_path=tmp_rules)
-        assert len(eng.list_rules()) == 0
+        s = WebhookStore(rules_path=tmp_rules)
+        assert len(s.list_rules()) == 0
 
 
-# ── FFT / band power helpers ──────────────────────────────────────────────
+# ── HTTP relay ─────────────────────────────────────────────────────────────
 
-class TestFFTHelpers:
-    def test_compute_psd_shape(self):
-        samples = np.random.randn(FFT_SIZE)
-        psd = _compute_psd(samples)
-        assert psd.shape == (FFT_SIZE // 2 + 1,)
-
-    def test_band_power_nonnegative(self):
-        psd = np.abs(np.random.randn(FFT_SIZE // 2 + 1))
-        for band in BANDS:
-            assert _band_power(psd, band) >= 0
-
-    def test_alpha_peak_detectable(self):
-        """Pure 10 Hz sine should have strong alpha band power."""
-        t = np.arange(FFT_SIZE) / SAMPLE_RATE
-        sine = 50 * np.sin(2 * np.pi * 10 * t)
-        psd = _compute_psd(sine)
-        alpha_power = _band_power(psd, "alpha")
-        delta_power = _band_power(psd, "delta")
-        assert alpha_power > delta_power * 5  # alpha dominates
-
-
-# ── Trigger evaluation ─────────────────────────────────────────────────────
-
-class TestTriggerEvaluation:
-    def _make_powers(self, alpha=10.0, beta=5.0, theta=3.0):
-        """Helper: build band_powers and amplitudes dicts for 16 channels."""
-        bp = {}
-        amps = {}
-        for ch in range(16):
-            bp[ch] = {"delta": 2.0, "theta": theta, "alpha": alpha,
-                      "beta": beta, "gamma": 1.0}
-            amps[ch] = 80.0
-        return bp, amps
-
-    def test_band_power_above_triggers(self, engine):
-        rule = WebhookRule(trigger_type="band_power_above",
-                           params={"band": "alpha", "channel": 0, "threshold": 8})
-        bp, amps = self._make_powers(alpha=12.0)
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-        assert val == 12.0
-
-    def test_band_power_above_no_trigger(self, engine):
-        rule = WebhookRule(trigger_type="band_power_above",
-                           params={"band": "alpha", "channel": 0, "threshold": 20})
-        bp, amps = self._make_powers(alpha=12.0)
-        triggered, _ = engine._evaluate_rule(rule, bp, amps)
-        assert not triggered
-
-    def test_band_power_below(self, engine):
-        rule = WebhookRule(trigger_type="band_power_below",
-                           params={"band": "beta", "channel": 0, "threshold": 10})
-        bp, amps = self._make_powers(beta=5.0)
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-        assert val == 5.0
-
-    def test_amplitude_above(self, engine):
-        rule = WebhookRule(trigger_type="amplitude_above",
-                           params={"channel": 0, "threshold": 50})
-        bp, amps = self._make_powers()
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-        assert val == 80.0
-
-    def test_amplitude_below(self, engine):
-        rule = WebhookRule(trigger_type="amplitude_below",
-                           params={"channel": 0, "threshold": 100})
-        bp, amps = self._make_powers()
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-
-    def test_band_ratio_above(self, engine):
-        rule = WebhookRule(trigger_type="band_ratio_above",
-                           params={"numerator": "alpha", "denominator": "theta",
-                                   "channel": 0, "threshold": 2.0})
-        bp, amps = self._make_powers(alpha=10.0, theta=3.0)
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-        assert abs(val - 10.0 / 3.0) < 0.01
-
-    def test_band_ratio_below(self, engine):
-        rule = WebhookRule(trigger_type="band_ratio_below",
-                           params={"numerator": "theta", "denominator": "alpha",
-                                   "channel": 0, "threshold": 0.5})
-        bp, amps = self._make_powers(alpha=10.0, theta=3.0)
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-        assert val < 0.5
-
-    def test_avg_channel(self, engine):
-        rule = WebhookRule(trigger_type="band_power_above",
-                           params={"band": "alpha", "channel": "avg", "threshold": 5})
-        bp, amps = self._make_powers(alpha=10.0)
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert triggered
-        assert val == 10.0  # all channels have alpha=10
-
-    def test_ratio_zero_denominator(self, engine):
-        rule = WebhookRule(trigger_type="band_ratio_above",
-                           params={"numerator": "alpha", "denominator": "gamma",
-                                   "channel": 0, "threshold": 1})
-        bp, amps = self._make_powers()
-        bp[0]["gamma"] = 0.0
-        triggered, val = engine._evaluate_rule(rule, bp, amps)
-        assert not triggered
-        assert val == 0.0
-
-
-# ── HTTP delivery ──────────────────────────────────────────────────────────
-
-class TestHTTPDelivery:
-    def test_render_default_body(self, engine):
-        rule = WebhookRule(name="Test", trigger_type="band_power_above",
-                           params={"threshold": 10, "channel": 0})
-        body = engine._render_body(rule, 15.5)
-        data = json.loads(body)
-        assert data["event"] == "band_power_above"
-        assert data["value"] == 15.5
-        assert data["rule"] == "Test"
-
-    def test_render_custom_template(self, engine):
-        rule = WebhookRule(name="Test", trigger_type="amplitude_above",
-                           params={"threshold": 100, "channel": 3},
-                           body_template='{"alert":"$trigger_type","ch":$channel,"v":$value}')
-        body = engine._render_body(rule, 120.0)
-        data = json.loads(body)
-        assert data["alert"] == "amplitude_above"
-        assert data["ch"] == "3"
-        assert data["v"] == "120.0"
-
+class TestHTTPRelay:
     @patch("pieeg_server.webhooks.urlopen")
-    def test_fire_http_sends_post(self, mock_urlopen, engine):
+    def test_send_http_post(self, mock_urlopen, store):
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
@@ -277,23 +128,83 @@ class TestHTTPDelivery:
         rule = WebhookRule(name="Test", url="https://example.com/hook",
                            trigger_type="band_power_above",
                            params={"threshold": 10})
-        engine._fire_http(rule, 15.0)
+        store._send_http(rule, 15.0)
         mock_urlopen.assert_called_once()
         req = mock_urlopen.call_args[0][0]
         assert req.full_url == "https://example.com/hook"
         assert req.method == "POST"
 
+    @patch("pieeg_server.webhooks.urlopen")
+    def test_send_http_with_auth_header(self, mock_urlopen, store):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        rule = WebhookRule(name="Auth", url="https://example.com/hook",
+                           headers={"Authorization": "Bearer tok123"},
+                           params={})
+        store._send_http(rule, 5.0)
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer tok123"
+
     @patch("pieeg_server.webhooks.urlopen", side_effect=Exception("timeout"))
-    def test_fire_http_handles_failure(self, mock_urlopen, engine):
+    def test_send_http_handles_failure(self, mock_urlopen, store):
         rule = WebhookRule(name="Test", url="https://fail.com",
                            trigger_type="band_power_above", params={})
         # Should not raise
-        engine._fire_http(rule, 10.0)
+        store._send_http(rule, 10.0)
 
 
-# ── Engine cleanup ─────────────────────────────────────────────────────────
+# ── fire_rule with cooldown ───────────────────────────────────────────────
+
+class TestFireRule:
+    @pytest.mark.asyncio
+    @patch("pieeg_server.webhooks.urlopen")
+    async def test_fire_rule_success(self, mock_urlopen, store):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        r = store.create_rule({"name": "Fire", "url": "https://a.com", "cooldown": 0.1})
+        result = await store.fire_rule(r["id"], 42.0)
+        assert result["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_fire_rule_not_found(self, store):
+        result = await store.fire_rule("nonexistent", 0)
+        assert result["ok"] is False
+        assert result["error"] == "rule_not_found"
+
+    @pytest.mark.asyncio
+    @patch("pieeg_server.webhooks.urlopen")
+    async def test_fire_rule_cooldown(self, mock_urlopen, store):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        r = store.create_rule({"name": "CD", "url": "https://a.com", "cooldown": 60})
+        result1 = await store.fire_rule(r["id"], 1.0)
+        assert result1["ok"] is True
+        result2 = await store.fire_rule(r["id"], 2.0)
+        assert result2["ok"] is False
+        assert result2["error"] == "cooldown"
+
+    @pytest.mark.asyncio
+    async def test_fire_rule_no_url(self, store):
+        r = store.create_rule({"name": "NoURL", "url": ""})
+        result = await store.fire_rule(r["id"], 1.0)
+        assert result["ok"] is False
+        assert result["error"] == "no_url"
+
+
+# ── Cleanup ────────────────────────────────────────────────────────────────
 
 class TestCleanup:
-    def test_stop_unsubscribes(self, engine, mock_acq):
-        engine.stop()
-        mock_acq.unsubscribe.assert_called_once()
+    def test_stop(self, store):
+        store.stop()  # should not raise

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,299 @@
+"""
+Tests for the webhook engine — rule CRUD, trigger evaluation, persistence.
+"""
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from pieeg_server.webhooks import (
+    WebhookEngine,
+    WebhookRule,
+    _band_power,
+    _compute_psd,
+    _freqs,
+    BANDS,
+    FFT_SIZE,
+    SAMPLE_RATE,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_rules(tmp_path):
+    return tmp_path / "webhooks.json"
+
+
+@pytest.fixture
+def mock_acq():
+    """Minimal acquisition mock with subscribe/unsubscribe."""
+    acq = MagicMock()
+    acq.subscribe.return_value = asyncio.Queue(maxsize=2048)
+    acq.unsubscribe = MagicMock()
+    return acq
+
+
+@pytest.fixture
+def engine(mock_acq, tmp_rules):
+    return WebhookEngine(mock_acq, num_channels=16, rules_path=tmp_rules)
+
+
+# ── WebhookRule unit tests ─────────────────────────────────────────────────
+
+class TestWebhookRule:
+    def test_default_id_generated(self):
+        r = WebhookRule(name="test")
+        assert r.id
+        assert len(r.id) == 8
+
+    def test_roundtrip_dict(self):
+        r = WebhookRule(name="Alpha Alert", trigger_type="band_power_above",
+                        params={"band": "alpha", "threshold": 10},
+                        url="https://example.com/hook", cooldown=5)
+        d = r.to_dict()
+        assert d["name"] == "Alpha Alert"
+        assert d["trigger_type"] == "band_power_above"
+        r2 = WebhookRule.from_dict(d)
+        assert r2.id == r.id
+        assert r2.name == r.name
+        assert r2.params == r.params
+        assert r2.url == r.url
+
+    def test_from_dict_ignores_unknown_keys(self):
+        d = {"name": "test", "unknown_field": True}
+        r = WebhookRule.from_dict(d)
+        assert r.name == "test"
+
+
+# ── Rule CRUD ──────────────────────────────────────────────────────────────
+
+class TestRuleCRUD:
+    def test_create_and_list(self, engine):
+        result = engine.create_rule({
+            "name": "Test1",
+            "trigger_type": "band_power_above",
+            "params": {"band": "alpha", "threshold": 15},
+            "url": "https://example.com",
+            "cooldown": 10,
+        })
+        assert result["name"] == "Test1"
+        assert result["id"]
+        rules = engine.list_rules()
+        assert len(rules) == 1
+        assert rules[0]["id"] == result["id"]
+
+    def test_update(self, engine):
+        r = engine.create_rule({"name": "Rule1", "url": "https://a.com"})
+        updated = engine.update_rule(r["id"], {"name": "Updated"})
+        assert updated["name"] == "Updated"
+        assert updated["url"] == "https://a.com"
+
+    def test_update_nonexistent(self, engine):
+        assert engine.update_rule("nope", {"name": "x"}) is None
+
+    def test_delete(self, engine):
+        r = engine.create_rule({"name": "ToDelete"})
+        assert engine.delete_rule(r["id"]) is True
+        assert len(engine.list_rules()) == 0
+
+    def test_delete_nonexistent(self, engine):
+        assert engine.delete_rule("nope") is False
+
+    def test_get_rule(self, engine):
+        r = engine.create_rule({"name": "Find me"})
+        found = engine.get_rule(r["id"])
+        assert found["name"] == "Find me"
+
+    def test_get_rule_nonexistent(self, engine):
+        assert engine.get_rule("nope") is None
+
+
+# ── Persistence ────────────────────────────────────────────────────────────
+
+class TestPersistence:
+    def test_save_and_reload(self, mock_acq, tmp_rules):
+        eng1 = WebhookEngine(mock_acq, rules_path=tmp_rules)
+        eng1.create_rule({"name": "Persistent", "url": "https://a.com"})
+        assert tmp_rules.exists()
+
+        eng2 = WebhookEngine(mock_acq, rules_path=tmp_rules)
+        rules = eng2.list_rules()
+        assert len(rules) == 1
+        assert rules[0]["name"] == "Persistent"
+
+    def test_corrupt_file_fallback(self, mock_acq, tmp_rules):
+        tmp_rules.write_text("NOT JSON")
+        eng = WebhookEngine(mock_acq, rules_path=tmp_rules)
+        assert len(eng.list_rules()) == 0
+
+
+# ── FFT / band power helpers ──────────────────────────────────────────────
+
+class TestFFTHelpers:
+    def test_compute_psd_shape(self):
+        samples = np.random.randn(FFT_SIZE)
+        psd = _compute_psd(samples)
+        assert psd.shape == (FFT_SIZE // 2 + 1,)
+
+    def test_band_power_nonnegative(self):
+        psd = np.abs(np.random.randn(FFT_SIZE // 2 + 1))
+        for band in BANDS:
+            assert _band_power(psd, band) >= 0
+
+    def test_alpha_peak_detectable(self):
+        """Pure 10 Hz sine should have strong alpha band power."""
+        t = np.arange(FFT_SIZE) / SAMPLE_RATE
+        sine = 50 * np.sin(2 * np.pi * 10 * t)
+        psd = _compute_psd(sine)
+        alpha_power = _band_power(psd, "alpha")
+        delta_power = _band_power(psd, "delta")
+        assert alpha_power > delta_power * 5  # alpha dominates
+
+
+# ── Trigger evaluation ─────────────────────────────────────────────────────
+
+class TestTriggerEvaluation:
+    def _make_powers(self, alpha=10.0, beta=5.0, theta=3.0):
+        """Helper: build band_powers and amplitudes dicts for 16 channels."""
+        bp = {}
+        amps = {}
+        for ch in range(16):
+            bp[ch] = {"delta": 2.0, "theta": theta, "alpha": alpha,
+                      "beta": beta, "gamma": 1.0}
+            amps[ch] = 80.0
+        return bp, amps
+
+    def test_band_power_above_triggers(self, engine):
+        rule = WebhookRule(trigger_type="band_power_above",
+                           params={"band": "alpha", "channel": 0, "threshold": 8})
+        bp, amps = self._make_powers(alpha=12.0)
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+        assert val == 12.0
+
+    def test_band_power_above_no_trigger(self, engine):
+        rule = WebhookRule(trigger_type="band_power_above",
+                           params={"band": "alpha", "channel": 0, "threshold": 20})
+        bp, amps = self._make_powers(alpha=12.0)
+        triggered, _ = engine._evaluate_rule(rule, bp, amps)
+        assert not triggered
+
+    def test_band_power_below(self, engine):
+        rule = WebhookRule(trigger_type="band_power_below",
+                           params={"band": "beta", "channel": 0, "threshold": 10})
+        bp, amps = self._make_powers(beta=5.0)
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+        assert val == 5.0
+
+    def test_amplitude_above(self, engine):
+        rule = WebhookRule(trigger_type="amplitude_above",
+                           params={"channel": 0, "threshold": 50})
+        bp, amps = self._make_powers()
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+        assert val == 80.0
+
+    def test_amplitude_below(self, engine):
+        rule = WebhookRule(trigger_type="amplitude_below",
+                           params={"channel": 0, "threshold": 100})
+        bp, amps = self._make_powers()
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+
+    def test_band_ratio_above(self, engine):
+        rule = WebhookRule(trigger_type="band_ratio_above",
+                           params={"numerator": "alpha", "denominator": "theta",
+                                   "channel": 0, "threshold": 2.0})
+        bp, amps = self._make_powers(alpha=10.0, theta=3.0)
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+        assert abs(val - 10.0 / 3.0) < 0.01
+
+    def test_band_ratio_below(self, engine):
+        rule = WebhookRule(trigger_type="band_ratio_below",
+                           params={"numerator": "theta", "denominator": "alpha",
+                                   "channel": 0, "threshold": 0.5})
+        bp, amps = self._make_powers(alpha=10.0, theta=3.0)
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+        assert val < 0.5
+
+    def test_avg_channel(self, engine):
+        rule = WebhookRule(trigger_type="band_power_above",
+                           params={"band": "alpha", "channel": "avg", "threshold": 5})
+        bp, amps = self._make_powers(alpha=10.0)
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert triggered
+        assert val == 10.0  # all channels have alpha=10
+
+    def test_ratio_zero_denominator(self, engine):
+        rule = WebhookRule(trigger_type="band_ratio_above",
+                           params={"numerator": "alpha", "denominator": "gamma",
+                                   "channel": 0, "threshold": 1})
+        bp, amps = self._make_powers()
+        bp[0]["gamma"] = 0.0
+        triggered, val = engine._evaluate_rule(rule, bp, amps)
+        assert not triggered
+        assert val == 0.0
+
+
+# ── HTTP delivery ──────────────────────────────────────────────────────────
+
+class TestHTTPDelivery:
+    def test_render_default_body(self, engine):
+        rule = WebhookRule(name="Test", trigger_type="band_power_above",
+                           params={"threshold": 10, "channel": 0})
+        body = engine._render_body(rule, 15.5)
+        data = json.loads(body)
+        assert data["event"] == "band_power_above"
+        assert data["value"] == 15.5
+        assert data["rule"] == "Test"
+
+    def test_render_custom_template(self, engine):
+        rule = WebhookRule(name="Test", trigger_type="amplitude_above",
+                           params={"threshold": 100, "channel": 3},
+                           body_template='{"alert":"$trigger_type","ch":$channel,"v":$value}')
+        body = engine._render_body(rule, 120.0)
+        data = json.loads(body)
+        assert data["alert"] == "amplitude_above"
+        assert data["ch"] == "3"
+        assert data["v"] == "120.0"
+
+    @patch("pieeg_server.webhooks.urlopen")
+    def test_fire_http_sends_post(self, mock_urlopen, engine):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        rule = WebhookRule(name="Test", url="https://example.com/hook",
+                           trigger_type="band_power_above",
+                           params={"threshold": 10})
+        engine._fire_http(rule, 15.0)
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://example.com/hook"
+        assert req.method == "POST"
+
+    @patch("pieeg_server.webhooks.urlopen", side_effect=Exception("timeout"))
+    def test_fire_http_handles_failure(self, mock_urlopen, engine):
+        rule = WebhookRule(name="Test", url="https://fail.com",
+                           trigger_type="band_power_above", params={})
+        # Should not raise
+        engine._fire_http(rule, 10.0)
+
+
+# ── Engine cleanup ─────────────────────────────────────────────────────────
+
+class TestCleanup:
+    def test_stop_unsubscribes(self, engine, mock_acq):
+        engine.stop()
+        mock_acq.unsubscribe.assert_called_once()


### PR DESCRIPTION
Adds a webhook “engine” to PiEEG: the server persists webhook rules and relays outbound HTTP requests, while the dashboard UI lets users create rules and performs client-side trigger evaluation (FFT-based) to decide when to fire.