### PR TITLE
fix: update Python requirement to 3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ pytest -v                 # verbose output
 ./scripts/build_release.sh --upload   # also uploads to PyPI
 ```
 
-Requires Node.js >= 18 and Python >= 3.11 on your **dev machine** (not on the Pi).
+Requires Node.js >= 18 and Python >= 3.10 on your **dev machine** (not on the Pi).
 
 #### Release workflow
 

--- a/pieeg_server/doctor.py
+++ b/pieeg_server/doctor.py
@@ -73,10 +73,10 @@ def run_doctor(quiet: bool = False) -> int:
     ok(f"Python {platform.python_version()} ({sys.executable})")
 
     py = sys.version_info
-    if py.major < 3 or (py.major == 3 and py.minor < 11):
-        fail(f"Python 3.11+ required (found {py.major}.{py.minor})")
+    if py.major < 3 or (py.major == 3 and py.minor < 10):
+        fail(f"Python 3.10+ required (found {py.major}.{py.minor})")
     else:
-        ok(f"Python version OK (3.11+ required)")
+        ok(f"Python version OK (3.10+ required)")
 
     if platform.system() == "Linux":
         ok("Running on Linux")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pieeg-server"
 version = "0.21.0"
 description = "One-command local streaming server for PiEEG (8/16-channel EEG shield for Raspberry Pi)"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
     {name = "PiEEG Community"},
@@ -18,6 +18,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -9,7 +9,7 @@
 #
 # Requirements (on your dev machine, NOT on the Pi):
 #   - Node.js >= 18  (for Vite build)
-#   - Python >= 3.11 (build + twine)
+#   - Python >= 3.10 (build + twine)
 # ============================================================
 set -euo pipefail
 

--- a/setup.sh
+++ b/setup.sh
@@ -130,8 +130,8 @@ PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.versi
 PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
 PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
 
-if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -lt 11 ]; }; then
-    die "Python 3.11+ is required, but found Python $PY_VERSION. Upgrade your OS or install a newer Python."
+if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -lt 10 ]; }; then
+    die "Python 3.10+ is required, but found Python $PY_VERSION. Upgrade your OS or install a newer Python."
 fi
 
 ok "Python $PY_VERSION"


### PR DESCRIPTION
Updates the project’s declared minimum supported Python version from 3.11+ to 3.10+ across packaging metadata and installer/diagnostic checks.