### PR TITLE
feat: add interactive BLE device scanning and selection

### DIFF
--- a/pieeg_server/__main__.py
+++ b/pieeg_server/__main__.py
@@ -280,9 +280,14 @@ def _make_hardware(args, logger):
         logger.info("Starting in MOCK mode (%d-channel synthetic EEG data)", num_ch)
         hw = MockHardware(num_channels=num_ch)
     elif _is_ble_device(device):
-        from .ironbci import IronBCIHardware
+        from .ironbci import IronBCIHardware, scan_ble_devices
         ble_name = getattr(args, "ble_name", "EAREEG")
         ble_addr = getattr(args, "ble_address", None)
+
+        # Interactive scan if no address provided
+        if not ble_addr:
+            ble_addr = _ble_interactive_scan(ble_name, logger)
+
         logger.info(
             "Initializing IronBCI-%d (BLE name=%s, address=%s)...",
             num_ch, ble_name, ble_addr or "auto-scan",
@@ -299,6 +304,68 @@ def _make_hardware(args, logger):
     if not args.mock and not _is_ble_device(device):
         logger.info("Hardware initialized - ADCs configured, LEDs should be ON")
     return hw
+
+
+def _ble_interactive_scan(ble_name: str, logger) -> str | None:
+    """Scan for BLE devices and let the user pick one interactively.
+
+    Returns the selected BLE address, or None to fall back to name-based scan.
+    """
+    import asyncio as _aio
+    from .ironbci import scan_ble_devices
+
+    print(f"\n  Scanning for BLE devices (8 s) ...")
+    try:
+        devices = _aio.run(scan_ble_devices(timeout=8.0))
+    except Exception as e:
+        logger.warning("BLE scan failed: %s — falling back to name scan", e)
+        return None
+
+    if not devices:
+        print("  No BLE devices found. Will try connecting by name...\n")
+        return None
+
+    # Highlight matching devices
+    matches = [d for d in devices if d["name"] == ble_name]
+    others = [d for d in devices if d["name"] != ble_name]
+
+    print(f"\n  Found {len(devices)} BLE device(s):\n")
+    print(f"  {'#':<4} {'Name':<24} {'Address':<20} {'RSSI'}")
+    print(f"  {'—'*4} {'—'*24} {'—'*20} {'—'*6}")
+
+    idx = 1
+    for d in matches + others:
+        rssi_str = f"{d['rssi']} dBm" if d["rssi"] is not None else "?"
+        marker = " ◀ match" if d["name"] == ble_name else ""
+        print(f"  {idx:<4} {d['name']:<24} {d['address']:<20} {rssi_str}{marker}")
+        idx += 1
+
+    # Auto-connect if exactly one matching device
+    ordered = matches + others
+    if len(matches) == 1:
+        addr = matches[0]["address"]
+        print(f"\n  Auto-selecting '{matches[0]['name']}' ({addr})\n")
+        return addr
+
+    # Prompt user to pick
+    print()
+    while True:
+        try:
+            choice = input("  Select device # (or Enter to scan by name): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return None
+        if not choice:
+            return None
+        try:
+            num = int(choice)
+            if 1 <= num <= len(ordered):
+                selected = ordered[num - 1]
+                print(f"  → Connecting to '{selected['name']}' ({selected['address']})\n")
+                return selected["address"]
+        except ValueError:
+            pass
+        print(f"  Invalid choice. Enter 1-{len(ordered)} or press Enter to skip.")
 
 
 def main():

--- a/pieeg_server/ironbci.py
+++ b/pieeg_server/ironbci.py
@@ -82,6 +82,29 @@ def parse_samples(data: bytes | list[int], num_channels: int = 8) -> list[list[f
     return samples
 
 
+async def scan_ble_devices(timeout: float = 8.0) -> list[dict]:
+    """Scan for nearby BLE devices and return a list of dicts.
+
+    Each dict has keys: name, address, rssi.
+    Only returns devices with a non-empty name.
+    """
+    _require_bleak()
+    devices = await BleakScanner.discover(timeout=timeout)
+    results = []
+    for d in devices:
+        name = d.name or ""
+        if not name:
+            continue
+        results.append({
+            "name": name,
+            "address": d.address,
+            "rssi": d.rssi if hasattr(d, "rssi") else None,
+        })
+    # Sort by signal strength (strongest first)
+    results.sort(key=lambda d: d["rssi"] or -999, reverse=True)
+    return results
+
+
 class IronBCIHardware:
     """BLE hardware abstraction for IronBCI boards.
 

--- a/tests/test_ironbci.py
+++ b/tests/test_ironbci.py
@@ -232,6 +232,22 @@ class _FakeBLEDevice:
         self.rssi = rssi
 
 
+def _patch_bleak(monkeypatch, fake_devices):
+    """Stub BleakScanner and BleakClient at module level.
+
+    On CI (no bleak installed) these are None, so we cannot patch
+    attributes *on* them — we replace the module-level names instead.
+    """
+
+    class _FakeScanner:
+        @staticmethod
+        async def discover(timeout=5.0):
+            return fake_devices
+
+    monkeypatch.setattr("pieeg_server.ironbci.BleakScanner", _FakeScanner)
+    monkeypatch.setattr("pieeg_server.ironbci.BleakClient", object)  # truthy
+
+
 class TestScanBleDevices:
     """Tests for scan_ble_devices filtering and sorting."""
 
@@ -242,11 +258,7 @@ class TestScanBleDevices:
             _FakeBLEDevice("", "AA:BB:CC:DD:EE:02", -50),
             _FakeBLEDevice(None, "AA:BB:CC:DD:EE:03", -60),
         ]
-
-        async def _fake_discover(timeout=5.0):
-            return fake_devices
-
-        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+        _patch_bleak(monkeypatch, fake_devices)
 
         results = await scan_ble_devices(timeout=1.0)
         assert len(results) == 1
@@ -259,11 +271,7 @@ class TestScanBleDevices:
             _FakeBLEDevice("DeviceB", "AA:BB:CC:DD:EE:02", -30),
             _FakeBLEDevice("DeviceC", "AA:BB:CC:DD:EE:03", -55),
         ]
-
-        async def _fake_discover(timeout=5.0):
-            return fake_devices
-
-        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+        _patch_bleak(monkeypatch, fake_devices)
 
         results = await scan_ble_devices(timeout=1.0)
         assert [d["name"] for d in results] == ["DeviceB", "DeviceC", "DeviceA"]
@@ -276,11 +284,7 @@ class TestScanBleDevices:
             _FakeBLEDevice("NoRSSI", "AA:BB:CC:DD:EE:01", None),
             _FakeBLEDevice("StrongSignal", "AA:BB:CC:DD:EE:02", -20),
         ]
-
-        async def _fake_discover(timeout=5.0):
-            return fake_devices
-
-        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+        _patch_bleak(monkeypatch, fake_devices)
 
         results = await scan_ble_devices(timeout=1.0)
         assert results[0]["name"] == "StrongSignal"
@@ -289,10 +293,7 @@ class TestScanBleDevices:
 
     @pytest.mark.asyncio
     async def test_no_devices_returns_empty_list(self, monkeypatch):
-        async def _fake_discover(timeout=5.0):
-            return []
-
-        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+        _patch_bleak(monkeypatch, [])
 
         results = await scan_ble_devices(timeout=1.0)
         assert results == []
@@ -302,11 +303,7 @@ class TestScanBleDevices:
         fake_devices = [
             _FakeBLEDevice("TestDev", "11:22:33:44:55:66", -45),
         ]
-
-        async def _fake_discover(timeout=5.0):
-            return fake_devices
-
-        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+        _patch_bleak(monkeypatch, fake_devices)
 
         results = await scan_ble_devices(timeout=1.0)
         assert len(results) == 1
@@ -322,10 +319,7 @@ class TestScanBleDevices:
                 self.name = "BareDevice"
                 self.address = "FF:FF:FF:FF:FF:FF"
 
-        async def _fake_discover(timeout=5.0):
-            return [_NoRSSIDevice()]
-
-        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+        _patch_bleak(monkeypatch, [_NoRSSIDevice()])
 
         results = await scan_ble_devices(timeout=1.0)
         assert len(results) == 1

--- a/tests/test_ironbci.py
+++ b/tests/test_ironbci.py
@@ -1,13 +1,16 @@
 """
 Tests for IronBCI BLE driver — pure-Python logic (no BLE hardware needed).
 
-Tests packet parsing, voltage conversion, and class interface.
+Tests packet parsing, voltage conversion, class interface, and BLE scan logic.
 """
+
+import asyncio
 
 import pytest
 
 from pieeg_server.ironbci import (
     parse_samples,
+    scan_ble_devices,
     VREF,
     FULL_SCALE,
     SIGN_BIT,
@@ -216,3 +219,114 @@ class TestAcquisitionBLEFlag:
         assert acq._ble is False
         hw.close()
         loop.close()
+
+
+# --- Helpers for BLE scan tests ---
+
+class _FakeBLEDevice:
+    """Minimal stand-in for bleak.backends.device.BLEDevice."""
+
+    def __init__(self, name, address, rssi=None):
+        self.name = name
+        self.address = address
+        self.rssi = rssi
+
+
+class TestScanBleDevices:
+    """Tests for scan_ble_devices filtering and sorting."""
+
+    @pytest.mark.asyncio
+    async def test_unnamed_devices_are_skipped(self, monkeypatch):
+        fake_devices = [
+            _FakeBLEDevice("EAREEG", "AA:BB:CC:DD:EE:01", -40),
+            _FakeBLEDevice("", "AA:BB:CC:DD:EE:02", -50),
+            _FakeBLEDevice(None, "AA:BB:CC:DD:EE:03", -60),
+        ]
+
+        async def _fake_discover(timeout=5.0):
+            return fake_devices
+
+        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+
+        results = await scan_ble_devices(timeout=1.0)
+        assert len(results) == 1
+        assert results[0]["name"] == "EAREEG"
+
+    @pytest.mark.asyncio
+    async def test_sorted_by_rssi_descending(self, monkeypatch):
+        fake_devices = [
+            _FakeBLEDevice("DeviceA", "AA:BB:CC:DD:EE:01", -80),
+            _FakeBLEDevice("DeviceB", "AA:BB:CC:DD:EE:02", -30),
+            _FakeBLEDevice("DeviceC", "AA:BB:CC:DD:EE:03", -55),
+        ]
+
+        async def _fake_discover(timeout=5.0):
+            return fake_devices
+
+        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+
+        results = await scan_ble_devices(timeout=1.0)
+        assert [d["name"] for d in results] == ["DeviceB", "DeviceC", "DeviceA"]
+        assert results[0]["rssi"] == -30
+        assert results[-1]["rssi"] == -80
+
+    @pytest.mark.asyncio
+    async def test_none_rssi_sorted_last(self, monkeypatch):
+        fake_devices = [
+            _FakeBLEDevice("NoRSSI", "AA:BB:CC:DD:EE:01", None),
+            _FakeBLEDevice("StrongSignal", "AA:BB:CC:DD:EE:02", -20),
+        ]
+
+        async def _fake_discover(timeout=5.0):
+            return fake_devices
+
+        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+
+        results = await scan_ble_devices(timeout=1.0)
+        assert results[0]["name"] == "StrongSignal"
+        assert results[1]["name"] == "NoRSSI"
+        assert results[1]["rssi"] is None
+
+    @pytest.mark.asyncio
+    async def test_no_devices_returns_empty_list(self, monkeypatch):
+        async def _fake_discover(timeout=5.0):
+            return []
+
+        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+
+        results = await scan_ble_devices(timeout=1.0)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_result_dict_keys(self, monkeypatch):
+        fake_devices = [
+            _FakeBLEDevice("TestDev", "11:22:33:44:55:66", -45),
+        ]
+
+        async def _fake_discover(timeout=5.0):
+            return fake_devices
+
+        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+
+        results = await scan_ble_devices(timeout=1.0)
+        assert len(results) == 1
+        d = results[0]
+        assert d == {"name": "TestDev", "address": "11:22:33:44:55:66", "rssi": -45}
+
+    @pytest.mark.asyncio
+    async def test_device_without_rssi_attr(self, monkeypatch):
+        """Device object that lacks an rssi attribute entirely."""
+
+        class _NoRSSIDevice:
+            def __init__(self):
+                self.name = "BareDevice"
+                self.address = "FF:FF:FF:FF:FF:FF"
+
+        async def _fake_discover(timeout=5.0):
+            return [_NoRSSIDevice()]
+
+        monkeypatch.setattr("pieeg_server.ironbci.BleakScanner.discover", _fake_discover)
+
+        results = await scan_ble_devices(timeout=1.0)
+        assert len(results) == 1
+        assert results[0]["rssi"] is None


### PR DESCRIPTION
Adds an interactive BLE scanning flow to help users discover nearby devices and select a target address before initializing IronBCI BLE hardware.