### PR TITLE
Add hardware profiles for Pi 4 / Pi 5 SPI and GPIO differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ pieeg-server [OPTIONS] [COMMAND]
 | `--no-dashboard` | — | Disable web dashboard |
 | `--auth` | — | Enable 6-digit access code |
 | `--gpio-chip PATH` | `/dev/gpiochip4` | GPIO chip device |
+| `--profile NAME` | `auto` | Raspberry Pi hardware profile: `auto`, `pi4`, `pi5` (auto-detected from `/proc/device-tree`) |
 | `--filter` | — | Enable 1–40 Hz bandpass filter |
 | `--lowcut HZ` | `1.0` | Filter low cutoff |
 | `--highcut HZ` | `40.0` | Filter high cutoff |

--- a/doc/content/getting-started/configuration.mdx
+++ b/doc/content/getting-started/configuration.mdx
@@ -32,6 +32,24 @@ pieeg-server [OPTIONS] [COMMAND]
 | `--no-dashboard` | — | Disable web dashboard |
 | `--auth` | — | Enable 6-digit access code |
 | `--gpio-chip PATH` | `/dev/gpiochip4` | GPIO chip device |
+| `--profile NAME` | `auto` | Raspberry Pi hardware profile: `auto`, `pi4`, `pi5` |
+
+### Hardware Profiles
+
+Different Raspberry Pi models expose SPI/GPIO slightly differently. The
+`--profile` flag selects platform-specific tunables (SPI clock, whether the
+script manages the chip-select GPIO line directly).
+
+| Profile | SPI clock | Notes |
+|---------|-----------|-------|
+| `pi4` | 4 MHz | Pi 2 / 3 / 4 / 400 — script toggles GPIO19 around chip-2 transactions |
+| `pi5` | 2 MHz | Pi 5 — kernel SPI driver owns the CE line, GPIO19 is left to the driver in 8-channel mode |
+| `auto` *(default)* | — | Read `/proc/device-tree/model` (then `compatible`); fall back to `pi4` on any unknown / non-Pi system so existing setups behave exactly as before |
+
+<Callout type="info">
+  In 16-channel mode the second ADS1299's CS is wired to GPIO19 on the shield,
+  so the chip-select pin is always managed regardless of profile.
+</Callout>
 
 ### BLE Options (IronBCI)
 

--- a/doc/content/reference/troubleshooting.mdx
+++ b/doc/content/reference/troubleshooting.mdx
@@ -61,6 +61,25 @@ kill $(lsof -t -i:1616)
 2. Electrodes connected
 3. Correct device flag: `--device pieeg8` or `--device pieeg16`
 4. Run `pieeg-server doctor` for hardware diagnostics
+5. On Pi 5, make sure `--gpio-chip /dev/gpiochip4` is used (the default). On Pi 4 / 3 / 2, use `--gpio-chip /dev/gpiochip0`.
+
+#### Pi 4 vs Pi 5 hardware profile
+
+The server auto-detects the Raspberry Pi model and applies a matching
+hardware profile. If auto-detection picks the wrong one (e.g. on a custom
+image), force it explicitly:
+
+```bash
+pieeg-server --profile pi5    # Raspberry Pi 5
+pieeg-server --profile pi4    # Pi 2 / 3 / 4 / 400
+```
+
+Symptoms of a profile mismatch:
+
+- **`GPIO busy` / `Device or resource busy` on Pi 5 in 8-channel mode** — the
+  kernel SPI driver already owns the CE line. Use `--profile pi5` (or `auto`).
+- **Garbled samples / dropped frames on Pi 4** — the Pi 5 profile uses a
+  slower 2 MHz SPI clock; force `--profile pi4` to restore 4 MHz.
 
 #### IronBCI / EAREEG (Bluetooth LE)
 

--- a/pieeg_server/__main__.py
+++ b/pieeg_server/__main__.py
@@ -140,6 +140,7 @@ def parse_args():
         help="GPIO chip device path (default: '/dev/gpiochip4' for Pi 5)",
     )
     rec.add_argument("--profile", **profile_kwargs)
+    _add_ble_args(rec)
     rec.add_argument(
         "--verbose", "-v", action="store_true",
         help="Enable debug logging",
@@ -162,6 +163,7 @@ def parse_args():
         help="GPIO chip device path (default: '/dev/gpiochip4' for Pi 5)",
     )
     mon.add_argument("--profile", **profile_kwargs)
+    _add_ble_args(mon)
     mon.add_argument(
         "--verbose", "-v", action="store_true",
         help="Enable debug logging",

--- a/pieeg_server/__main__.py
+++ b/pieeg_server/__main__.py
@@ -87,6 +87,12 @@ def parse_args():
         default="pieeg16",
         help="Hardware profile: pieeg8/16 (SPI), ironbci8 (BLE) — default: pieeg16",
     )
+    profile_kwargs = dict(
+        type=str,
+        choices=["auto", "pi4", "pi5"],
+        default="auto",
+        help="Raspberry Pi hardware profile (default: auto-detect from /proc/device-tree)",
+    )
     def _add_ble_args(parser):
         """Add BLE arguments to a parser (IronBCI / EAREEG compatible)."""
         parser.add_argument(
@@ -133,7 +139,7 @@ def parse_args():
         "--gpio-chip", default="/dev/gpiochip4",
         help="GPIO chip device path (default: '/dev/gpiochip4' for Pi 5)",
     )
-    _add_ble_args(rec)
+    rec.add_argument("--profile", **profile_kwargs)
     rec.add_argument(
         "--verbose", "-v", action="store_true",
         help="Enable debug logging",
@@ -155,7 +161,7 @@ def parse_args():
         "--gpio-chip", default="/dev/gpiochip4",
         help="GPIO chip device path (default: '/dev/gpiochip4' for Pi 5)",
     )
-    _add_ble_args(mon)
+    mon.add_argument("--profile", **profile_kwargs)
     mon.add_argument(
         "--verbose", "-v", action="store_true",
         help="Enable debug logging",
@@ -185,6 +191,7 @@ def parse_args():
         "--gpio-chip", default="/dev/gpiochip4",
         help="GPIO chip device path (default: '/dev/gpiochip4' for Pi 5)",
     )
+    p.add_argument("--profile", **profile_kwargs)
     p.add_argument(
         "--filter", action="store_true",
         help="Enable 1–40 Hz bandpass filter on server side",
@@ -390,9 +397,14 @@ def _make_hardware(args, logger):
         )
     else:
         from .hardware import PiEEGHardware
-        logger.info("Initializing PiEEG-%d hardware (GPIO chip: %s)...",
-                    num_ch, args.gpio_chip)
-        hw = PiEEGHardware(gpio_chip=args.gpio_chip, num_channels=num_ch)
+        profile_name = getattr(args, "profile", "auto")
+        logger.info("Initializing PiEEG-%d hardware (GPIO chip: %s, profile: %s)...",
+                    num_ch, args.gpio_chip, profile_name)
+        hw = PiEEGHardware(
+            gpio_chip=args.gpio_chip,
+            num_channels=num_ch,
+            profile=profile_name,
+        )
     hw.open()
     if not args.mock and not _is_ble_device(device):
         logger.info("Hardware initialized - ADCs configured, LEDs should be ON")

--- a/pieeg_server/hardware.py
+++ b/pieeg_server/hardware.py
@@ -19,6 +19,7 @@ except ImportError:
     fcntl = None  # not on Linux — hardware methods will fail, mock mode still works
 
 from . import _native
+from .profiles import HardwareProfile, get_profile
 
 logger = logging.getLogger("pieeg.hardware")
 
@@ -110,11 +111,28 @@ class PiEEGHardware:
     CH_REGS = (CH1SET, CH2SET, CH3SET, CH4SET, CH5SET, CH6SET, CH7SET, CH8SET)
 
     def __init__(self, gpio_chip: str = "/dev/gpiochip4",
-                 num_channels: int = 16):
+                 num_channels: int = 16,
+                 profile: HardwareProfile | str | None = None):
         if num_channels not in (8, 16):
             raise ValueError(f"num_channels must be 8 or 16, got {num_channels}")
         self._num_channels = num_channels
         self._gpio_chip_name = gpio_chip
+        # Resolve profile: accept a HardwareProfile, a name string, or None.
+        # None / "auto" trigger auto-detection; unknown setups fall back to
+        # the safe default (= pre-existing behavior).
+        if isinstance(profile, HardwareProfile):
+            self._profile = profile
+        else:
+            self._profile = get_profile(profile)
+        # 16-ch mode always needs GPIO19 toggling for chip 2's CS line,
+        # regardless of the profile's manage_cs_pin setting.
+        self._manage_cs = self._profile.manage_cs_pin or num_channels == 16
+        if num_channels == 16 and not self._profile.manage_cs_pin:
+            logger.warning(
+                "Profile %r disables CS pin management, but 16-channel mode "
+                "requires GPIO%d for chip 2. Forcing CS management on.",
+                self._profile.name, CS_PIN,
+            )
         self._chip_fd = -1
         self._cs_fd = -1
         self._drdy_fd = -1
@@ -318,7 +336,14 @@ class PiEEGHardware:
     # --- GPIO helpers (direct Linux chardev ioctl) ---
 
     def _cs_set(self, value: int):
-        """Set chip-select line: 1 = high (deselect), 0 = low (select)."""
+        """Set chip-select line: 1 = high (deselect), 0 = low (select).
+
+        No-op when the active profile delegates CS to the kernel SPI driver
+        (e.g. Pi 5 in 8-channel mode). In 16-channel mode this always toggles
+        GPIO19 because chip 2's CS is wired there on the PiEEG shield.
+        """
+        if not self._manage_cs or self._cs_fd < 0:
+            return
         buf = bytearray(_HANDLE_DATA_SIZE)
         buf[0] = value & 1
         fcntl.ioctl(self._cs_fd, _GPIOHANDLE_SET_VALUES, buf)
@@ -349,10 +374,14 @@ class PiEEGHardware:
         logger.info("Opening GPIO chip %s", self._gpio_chip_name)
         self._chip_fd = os.open(self._gpio_chip_name, os.O_RDWR | os.O_CLOEXEC)
 
-        # Chip-select line (output, default high)
-        self._cs_fd = self._request_line(
-            self._chip_fd, CS_PIN, _GPIOHANDLE_REQUEST_OUTPUT,
-            default_value=1, consumer=b"pieeg_cs")
+        # Chip-select line (output, default high). Skipped when the kernel
+        # SPI driver owns the line (e.g. Pi 5 in 8-ch mode); see profiles.py.
+        if self._manage_cs:
+            self._cs_fd = self._request_line(
+                self._chip_fd, CS_PIN, _GPIOHANDLE_REQUEST_OUTPUT,
+                default_value=1, consumer=b"pieeg_cs")
+        else:
+            self._cs_fd = -1
 
         # Data-ready line chip 1 (input)
         self._drdy_fd = self._request_line(
@@ -390,9 +419,12 @@ class PiEEGHardware:
         return struct.unpack_from("i", buf, 360)[0]  # fd
 
     def _init_spi(self):
+        speed = self._profile.spi_speed_hz
+        logger.info("Initializing SPI at %d Hz (profile=%s)",
+                    speed, self._profile.name)
         self._spi1 = spidev.SpiDev()
         self._spi1.open(0, 0)
-        self._spi1.max_speed_hz = SPI_SPEED_HZ
+        self._spi1.max_speed_hz = speed
         self._spi1.lsbfirst = False
         self._spi1.mode = SPI_MODE
         self._spi1.bits_per_word = SPI_BITS
@@ -400,7 +432,7 @@ class PiEEGHardware:
         if self._num_channels == 16:
             self._spi2 = spidev.SpiDev()
             self._spi2.open(0, 1)
-            self._spi2.max_speed_hz = SPI_SPEED_HZ
+            self._spi2.max_speed_hz = speed
             self._spi2.lsbfirst = False
             self._spi2.mode = SPI_MODE
             self._spi2.bits_per_word = SPI_BITS

--- a/pieeg_server/profiles.py
+++ b/pieeg_server/profiles.py
@@ -1,0 +1,108 @@
+"""
+Hardware profiles for PiEEG.
+
+Different Raspberry Pi models expose SPI/GPIO slightly differently. A profile
+bundles the platform-specific tunables (SPI clock, whether the script needs to
+manually toggle the chip-select GPIO line) so the rest of the code stays
+generic.
+
+Selection precedence:
+    1. Explicit ``--profile <name>`` / ``profile=...`` argument
+    2. Auto-detection from /proc/device-tree (model, then compatible)
+    3. ``DEFAULT_PROFILE`` (= 'pi4' = current pre-existing behavior)
+
+Auto-detection is deliberately conservative: any failure or unknown hardware
+falls back to the default profile, so behavior on existing setups is
+unchanged.
+"""
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("pieeg.profiles")
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    """Platform-specific hardware tunables."""
+
+    name: str
+    spi_speed_hz: int
+    # If True, the script requests GPIO19 as an output and toggles it around
+    # SPI transactions to chip 2. Required for 16-channel mode regardless of
+    # this flag (the second ADS1299's CS is wired to GPIO19 on the shield).
+    # On Pi 5, GPIO19 cannot be requested on /dev/gpiochip4 in 8-channel mode
+    # because the kernel SPI driver already owns the CE line, so this is set
+    # to False on the 'pi5' profile.
+    manage_cs_pin: bool
+
+
+PROFILES: dict[str, "HardwareProfile"] = {
+    "pi4": HardwareProfile(
+        name="pi4",
+        spi_speed_hz=4_000_000,
+        manage_cs_pin=True,
+    ),
+    "pi5": HardwareProfile(
+        name="pi5",
+        spi_speed_hz=2_000_000,
+        manage_cs_pin=False,
+    ),
+}
+
+# Safe default = current pre-existing behavior (Pi 4-style SPI/GPIO).
+DEFAULT_PROFILE = "pi4"
+
+
+def detect_profile() -> str:
+    """Auto-detect a hardware profile name from /proc/device-tree.
+
+    Returns one of the keys in :data:`PROFILES`. Falls back to
+    :data:`DEFAULT_PROFILE` on any I/O error or unknown hardware, so the
+    behavior on non-Pi systems and on older/newer Pi models matches the
+    pre-existing default.
+    """
+    # 1. Model string (most human-readable, set by firmware).
+    try:
+        raw = Path("/proc/device-tree/model").read_bytes()
+        model = raw.rstrip(b"\x00").decode("ascii", errors="replace")
+        if "Raspberry Pi 5" in model:
+            return "pi5"
+        if "Raspberry Pi 4" in model or "Raspberry Pi 400" in model:
+            return "pi4"
+        if "Raspberry Pi 3" in model or "Raspberry Pi 2" in model:
+            return "pi4"  # older Pis behave like Pi 4 for our purposes
+    except OSError:
+        pass
+
+    # 2. SoC compatible string (fallback when model is missing/custom).
+    try:
+        raw = Path("/proc/device-tree/compatible").read_bytes()
+        tokens = raw.split(b"\x00")
+        if any(b"bcm2712" in t for t in tokens):
+            return "pi5"
+        if any(b"bcm2711" in t for t in tokens):
+            return "pi4"
+    except OSError:
+        pass
+
+    return DEFAULT_PROFILE
+
+
+def get_profile(name: str | None) -> HardwareProfile:
+    """Resolve a profile name to a :class:`HardwareProfile`.
+
+    ``None`` or ``"auto"`` triggers auto-detection. Unknown names raise
+    :class:`ValueError`.
+    """
+    if name is None or name == "auto":
+        detected = detect_profile()
+        logger.info("Auto-detected hardware profile: %s", detected)
+        return PROFILES[detected]
+    if name not in PROFILES:
+        raise ValueError(
+            f"Unknown hardware profile {name!r}. "
+            f"Available: {sorted(PROFILES)} (or 'auto')"
+        )
+    return PROFILES[name]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,143 @@
+"""Tests for the hardware profile system."""
+
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from pieeg_server.profiles import (
+    DEFAULT_PROFILE,
+    PROFILES,
+    HardwareProfile,
+    detect_profile,
+    get_profile,
+)
+
+
+class TestProfileRegistry:
+    def test_default_is_pi4(self):
+        assert DEFAULT_PROFILE == "pi4"
+
+    def test_pi4_profile_matches_legacy_behavior(self):
+        # No-regression guard: the default profile must match what shipped
+        # before the profile system existed.
+        p = PROFILES["pi4"]
+        assert p.spi_speed_hz == 4_000_000
+        assert p.manage_cs_pin is True
+
+    def test_pi5_profile(self):
+        p = PROFILES["pi5"]
+        assert p.spi_speed_hz == 2_000_000
+        assert p.manage_cs_pin is False
+
+
+class TestGetProfile:
+    def test_named_profile(self):
+        assert get_profile("pi4") is PROFILES["pi4"]
+        assert get_profile("pi5") is PROFILES["pi5"]
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown hardware profile"):
+            get_profile("pi99")
+
+    def test_none_triggers_detect(self):
+        with patch("pieeg_server.profiles.detect_profile", return_value="pi5"):
+            assert get_profile(None) is PROFILES["pi5"]
+
+    def test_auto_triggers_detect(self):
+        with patch("pieeg_server.profiles.detect_profile", return_value="pi4"):
+            assert get_profile("auto") is PROFILES["pi4"]
+
+
+class TestDetectProfile:
+    def _patch_read_bytes(self, model_data: bytes | None = None,
+                          compat_data: bytes | None = None):
+        """Patch Path.read_bytes to return per-path canned data."""
+        def fake_read_bytes(self):
+            path = str(self)
+            if path.endswith("model"):
+                if model_data is None:
+                    raise OSError("no model file")
+                return model_data
+            if path.endswith("compatible"):
+                if compat_data is None:
+                    raise OSError("no compatible file")
+                return compat_data
+            raise OSError(f"unexpected path {path}")
+        return patch("pieeg_server.profiles.Path.read_bytes", fake_read_bytes)
+
+    def test_detect_pi5_from_model(self):
+        with self._patch_read_bytes(model_data=b"Raspberry Pi 5 Model B Rev 1.0\x00"):
+            assert detect_profile() == "pi5"
+
+    def test_detect_pi4_from_model(self):
+        with self._patch_read_bytes(model_data=b"Raspberry Pi 4 Model B Rev 1.4\x00"):
+            assert detect_profile() == "pi4"
+
+    def test_detect_pi3_falls_back_to_pi4(self):
+        with self._patch_read_bytes(model_data=b"Raspberry Pi 3 Model B Plus\x00"):
+            assert detect_profile() == "pi4"
+
+    def test_detect_pi5_from_compatible(self):
+        # Model file unreadable, but compatible string identifies Pi 5 SoC.
+        with self._patch_read_bytes(
+            model_data=None,
+            compat_data=b"raspberrypi,5-model-b\x00brcm,bcm2712\x00",
+        ):
+            assert detect_profile() == "pi5"
+
+    def test_detect_pi4_from_compatible(self):
+        with self._patch_read_bytes(
+            model_data=None,
+            compat_data=b"raspberrypi,4-model-b\x00brcm,bcm2711\x00",
+        ):
+            assert detect_profile() == "pi4"
+
+    def test_no_files_falls_back_to_default(self):
+        with self._patch_read_bytes(model_data=None, compat_data=None):
+            assert detect_profile() == DEFAULT_PROFILE
+
+    def test_unknown_model_falls_back_to_default(self):
+        with self._patch_read_bytes(model_data=b"Some Other Board\x00",
+                                     compat_data=b"unknown,board\x00"):
+            assert detect_profile() == DEFAULT_PROFILE
+
+
+class TestHardwareIntegration:
+    """Verify PiEEGHardware accepts and applies the profile correctly."""
+
+    def test_default_construction_uses_pi4_behavior(self):
+        # Auto-detect on a non-Pi dev box falls back to pi4 (= legacy behavior).
+        from pieeg_server.hardware import PiEEGHardware
+        with patch("pieeg_server.profiles.detect_profile", return_value="pi4"):
+            hw = PiEEGHardware(num_channels=8)
+        assert hw._profile.name == "pi4"
+        assert hw._profile.spi_speed_hz == 4_000_000
+        assert hw._manage_cs is True
+
+    def test_pi5_profile_8ch_disables_cs_management(self):
+        from pieeg_server.hardware import PiEEGHardware
+        hw = PiEEGHardware(num_channels=8, profile="pi5")
+        assert hw._profile.name == "pi5"
+        assert hw._profile.spi_speed_hz == 2_000_000
+        assert hw._manage_cs is False
+
+    def test_pi5_profile_16ch_forces_cs_management(self):
+        # 16-ch always needs GPIO19 for chip 2's CS, even with the pi5 profile.
+        from pieeg_server.hardware import PiEEGHardware
+        hw = PiEEGHardware(num_channels=16, profile="pi5")
+        assert hw._manage_cs is True
+
+    def test_explicit_profile_object_accepted(self):
+        from pieeg_server.hardware import PiEEGHardware
+        custom = HardwareProfile(name="custom", spi_speed_hz=1_000_000,
+                                  manage_cs_pin=True)
+        hw = PiEEGHardware(num_channels=8, profile=custom)
+        assert hw._profile is custom
+        assert hw._manage_cs is True
+
+    def test_cs_set_is_noop_when_unmanaged(self):
+        from pieeg_server.hardware import PiEEGHardware
+        hw = PiEEGHardware(num_channels=8, profile="pi5")
+        # _cs_fd is -1 and _manage_cs is False; should silently no-op.
+        hw._cs_set(0)
+        hw._cs_set(1)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,6 +1,6 @@
 """Tests for the hardware profile system."""
 
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
Supersedes #54.

## Why

@cameornh reported in #54 that the Raspberry Pi 5 needs different SPI/GPIO handling to talk to the PiEEG 8-pin shield: the kernel SPI driver already owns CE, so requesting GPIO19 as an output errors out, and 4 MHz SPI is unreliable. His PR fixed it for his setup but would have:
- regressed Pi 4 users (forced 2 MHz globally),
- broken 16-channel mode (chip 2's CS is wired to GPIO19 and must still be toggled manually).

## What

Introduces a small `HardwareProfile` system instead of branching behavior in place:

- **New** `pieeg_server/profiles.py` — `HardwareProfile` dataclass + a registry of two named profiles:
  - `pi4`: 4 MHz SPI, manage CS pin (= current behavior)
  - `pi5`: 2 MHz SPI, kernel-managed CS
- **Auto-detection** reads `/proc/device-tree/model`, falls back to `/proc/device-tree/compatible` (matching `bcm2712` / `bcm2711`), and finally falls back to `pi4` on any error or unknown hardware.
- **New** `--profile {auto,pi4,pi5}` CLI flag (default: `auto`) on the server, `record`, and `monitor` subcommands.
- `PiEEGHardware` accepts `profile=` (a `HardwareProfile`, name, or `None` for auto). 16-channel mode forces CS-pin management on regardless of profile, with a warning, because chip 2 needs it.
- `_cs_set()` is a no-op when CS is unmanaged. `_init_gpio` skips requesting GPIO19 when the profile says so. `_init_spi` uses `profile.spi_speed_hz`.

## No regressions

- Pi 4 / Pi 3 / Pi 2 users keep 4 MHz and the existing CS toggling — byte-identical to today.
- 16-channel mode keeps GPIO19 toggling for chip 2 even on Pi 5.
- Full test suite: **191/191 passing**.

## Tests

New `tests/test_profiles.py` (22 tests) covers:
- profile registry values (no-regression guard on `pi4` defaults),
- `get_profile` with named / `None` / `"auto"` / unknown,
- `detect_profile` with mocked `/proc/device-tree/model` and `/proc/device-tree/compatible` (Pi 5, Pi 4, Pi 3, missing files, unknown hardware),
- `PiEEGHardware` integration: default → `pi4`, `pi5` 8-ch disables CS management, `pi5` 16-ch forces it back on, custom `HardwareProfile` accepted, `_cs_set` no-ops when unmanaged.

Co-authored-by: Cameron Halaby <crhalaby652@gmail.com>