### PR TITLE
OSC regions cli

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,0 +1,3 @@
+{
+  "tests/test_osc_vrchat.py": true
+}

--- a/pieeg_server/__main__.py
+++ b/pieeg_server/__main__.py
@@ -269,6 +269,10 @@ def parse_args():
         help="Seconds between OSC sends (default: 0.25 = 4 Hz)",
     )
     p.add_argument(
+        "--osc-regions-setup", action="store_true",
+        help="Interactive setup wizard for OSC/LSL channel regions (creates ~/.pieeg/lsl_groups.json)",
+    )
+    p.add_argument(
         "--lsl", action="store_true",
         help="Enable Lab Streaming Layer outlet on startup (pushes EEG samples via LSL)",
     )
@@ -524,6 +528,17 @@ def main():
     args = parse_args()
     _check_update()
 
+    # --- OSC/LSL Regions Setup (interactive wizard) ---
+    if getattr(args, 'osc_regions_setup', False):
+        from . import profiles
+        device = getattr(args, 'device', 'pieeg16')
+        num_channels = _num_channels_from_device(device)
+        profiles.setup_regions_interactive(num_channels)
+        # If user also passed --osc or --lsl, continue to server startup
+        # Otherwise, exit after setup
+        if not getattr(args, 'osc', False) and not getattr(args, 'lsl', False):
+            return
+
     # --- Doctor subcommand (no heavy deps needed) ---
     if args.command == "doctor":
         from .doctor import run_doctor
@@ -657,17 +672,26 @@ def main():
     # --- VRChat OSC bridge (optional, auto-starts with --osc) ---
     if getattr(args, 'osc', False):
         from .osc_vrchat import OSCConfig, VRChatOSCBridge  # noqa: F401
+        # Load channel groups from config file (same as LSL groups)
+        osc_groups = server._lsl_groups if server._lsl_groups else None
         osc_cfg = OSCConfig(
             host=args.osc_host,
             port=args.osc_port,
             mode=args.osc_mode,
             interval=args.osc_interval,
+            groups=osc_groups,
         )
         server.enable_osc(osc_cfg)
-        logger.info(
-            "VRChat OSC bridge configured: %s:%d  mode=%s  interval=%.2fs",
-            args.osc_host, args.osc_port, args.osc_mode, args.osc_interval,
-        )
+        if osc_groups:
+            logger.info(
+                "VRChat OSC bridge configured: %s:%d  mode=%s  interval=%.2fs  regions=%d",
+                args.osc_host, args.osc_port, args.osc_mode, args.osc_interval, len(osc_groups),
+            )
+        else:
+            logger.info(
+                "VRChat OSC bridge configured: %s:%d  mode=%s  interval=%.2fs",
+                args.osc_host, args.osc_port, args.osc_mode, args.osc_interval,
+            )
 
     # --- LSL outlet (optional, auto-starts with --lsl) ---
     if getattr(args, 'lsl', False):

--- a/pieeg_server/osc_vrchat.py
+++ b/pieeg_server/osc_vrchat.py
@@ -403,11 +403,21 @@ class VRChatOSCBridge:
         self._running = True
         self._init_buffers()
         self._open_socket()
-        logger.info(
-            "VRChat OSC bridge started → %s:%d  mode=%s  interval=%.2fs",
-            self._config.host, self._config.port,
-            self._config.mode, self._config.interval,
-        )
+        
+        # Log startup with region info
+        if self._group_targets:
+            logger.info(
+                "VRChat OSC bridge started → %s:%d  mode=%s  interval=%.2fs  streaming=%d regions",
+                self._config.host, self._config.port,
+                self._config.mode, self._config.interval,
+                len(self._group_targets),
+            )
+        else:
+            logger.info(
+                "VRChat OSC bridge started → %s:%d  mode=%s  interval=%.2fs  streaming=global average",
+                self._config.host, self._config.port,
+                self._config.mode, self._config.interval,
+            )
 
         if self._config.typing_indicator and self._config.mode in ("chatbox", "both"):
             self._send(osc_message("/chatbox/typing", ("T", None)))

--- a/pieeg_server/profiles.py
+++ b/pieeg_server/profiles.py
@@ -160,6 +160,144 @@ def load_lsl_groups() -> list[dict]:
         return []
 
 
+def setup_regions_interactive(num_channels: int = 16) -> list[dict]:
+    """Interactive setup wizard for channel regions/groups.
+
+    Args:
+        num_channels: Total number of EEG channels (8 or 16)
+
+    Returns:
+        List of region dicts in the format: [{"name": "Frontal", "channels": [0,1,2,3]}, ...]
+    """
+    import json
+
+    print("\n╭─────────────────────────────────────────────────────────────╮")
+    print("│  🧠  PiEEG Channel Regions Setup                            │")
+    print("╰─────────────────────────────────────────────────────────────╯\n")
+    print(f"Configuring regions for {num_channels}-channel device\n")
+    
+    # Common presets
+    presets = {
+        "8ch_frontal_occipital": {
+            "name": "Frontal/Occipital (8-ch)",
+            "regions": [
+                {"name": "Frontal", "channels": [0, 1, 2, 3]},
+                {"name": "Occipital", "channels": [4, 5, 6, 7]},
+            ]
+        },
+        "8ch_left_right": {
+            "name": "Left/Right Hemisphere (8-ch)",
+            "regions": [
+                {"name": "Left", "channels": [0, 2, 4, 6]},
+                {"name": "Right", "channels": [1, 3, 5, 7]},
+            ]
+        },
+        "16ch_four_regions": {
+            "name": "Frontal/Central/Parietal/Occipital (16-ch)",
+            "regions": [
+                {"name": "Frontal", "channels": [0, 1, 2, 3]},
+                {"name": "Central", "channels": [4, 5, 6, 7]},
+                {"name": "Parietal", "channels": [8, 9, 10, 11]},
+                {"name": "Occipital", "channels": [12, 13, 14, 15]},
+            ]
+        },
+        "16ch_left_right": {
+            "name": "Left/Right Hemisphere (16-ch)",
+            "regions": [
+                {"name": "Left", "channels": [0, 2, 4, 6, 8, 10, 12, 14]},
+                {"name": "Right", "channels": [1, 3, 5, 7, 9, 11, 13, 15]},
+            ]
+        },
+    }
+
+    # Filter presets by channel count
+    if num_channels == 8:
+        available = {k: v for k, v in presets.items() if k.startswith("8ch")}
+    elif num_channels == 16:
+        available = {k: v for k, v in presets.items() if k.startswith("16ch")}
+    else:
+        available = {}
+
+    print("Choose a preset or create custom regions:\n")
+    options = list(available.items())
+    for i, (key, preset) in enumerate(options, 1):
+        print(f"  {i}. {preset['name']}")
+        for region in preset['regions']:
+            ch_str = ", ".join(str(c) for c in region['channels'])
+            print(f"     • {region['name']}: channels [{ch_str}]")
+        print()
+    print(f"  {len(options) + 1}. Custom (manual configuration)")
+    print(f"  {len(options) + 2}. No regions (use global average)\n")
+
+    while True:
+        try:
+            choice = input("Select option: ").strip()
+            choice_num = int(choice)
+            if 1 <= choice_num <= len(options):
+                selected_preset = options[choice_num - 1][1]
+                regions = selected_preset['regions']
+                break
+            elif choice_num == len(options) + 1:
+                # Custom setup
+                regions = _custom_region_setup(num_channels)
+                break
+            elif choice_num == len(options) + 2:
+                # No regions
+                print("\n✓ Skipping region configuration (will use global average)\n")
+                return []
+            else:
+                print(f"Please enter a number between 1 and {len(options) + 2}")
+        except (ValueError, KeyboardInterrupt):
+            print("\n✗ Setup cancelled\n")
+            return []
+
+    # Save to config file
+    config_file = _get_config_dir() / "lsl_groups.json"
+    with config_file.open("w") as f:
+        json.dump(regions, f, indent=2)
+    
+    print(f"\n✓ Saved {len(regions)} regions to: {config_file}")
+    print("\nRegions configured:")
+    for region in regions:
+        ch_str = ", ".join(str(c) for c in region['channels'])
+        print(f"  • {region['name']}: channels [{ch_str}]")
+    print()
+    
+    return regions
+
+
+def _custom_region_setup(num_channels: int) -> list[dict]:
+    """Custom region setup (manual entry)."""
+    regions = []
+    print("\nCustom region setup")
+    print("Enter region names and channel lists (comma-separated indices)")
+    print("Press Enter with empty name to finish\n")
+    
+    while True:
+        name = input(f"Region name (or Enter to finish): ").strip()
+        if not name:
+            break
+        
+        while True:
+            try:
+                channels_str = input(f"  Channels for '{name}' (e.g., 0,1,2,3): ").strip()
+                channels = [int(c.strip()) for c in channels_str.split(",")]
+                # Validate
+                if not channels:
+                    print("    ✗ No channels specified")
+                    continue
+                if any(c < 0 or c >= num_channels for c in channels):
+                    print(f"    ✗ Channel indices must be 0-{num_channels - 1}")
+                    continue
+                regions.append({"name": name, "channels": channels})
+                print(f"    ✓ Added '{name}' with {len(channels)} channels")
+                break
+            except ValueError:
+                print("    ✗ Invalid format. Use comma-separated integers (e.g., 0,1,2,3)")
+    
+    return regions
+
+
 def save_lsl_groups(groups: list[dict]) -> None:
     """Save LSL channel groups to ~/.pieeg/lsl_groups.json.
 


### PR DESCRIPTION
Adds a CLI workflow for configuring EEG channel “regions” (channel groups) and wires that configuration into the VRChat OSC bridge so OSC can stream per-region values (or fall back to a global average).
