### PR TITLE
docs: clarify port conflict troubleshooting

### DIFF
--- a/doc/content/reference/troubleshooting.mdx
+++ b/doc/content/reference/troubleshooting.mdx
@@ -41,14 +41,17 @@ sudo reboot
 ### Port already in use
 
 ```
-Error: Address already in use (port 1616)
+Error: Address already in use (port 1616 or 1617)
 ```
 
-**Fix:** Stop the existing instance:
+**Fix:** Stop the existing instance or background service:
 ```bash
 sudo systemctl stop pieeg-server
+# prevent it from starting again after reboot
+sudo systemctl disable pieeg-server
 # or
 kill $(lsof -t -i:1616)
+kill $(lsof -t -i:1617)
 ```
 
 ### No data from hardware


### PR DESCRIPTION
## Summary
- mention that port conflicts can affect both the WebSocket port (1616) and dashboard port (1617)
- include disabling the systemd service when it keeps restarting after reboot
- add the matching 1617 lsof cleanup command

## Context
This mirrors the failure mode discussed in #57, where `pieeg-server --mock` failed because the dashboard port was already bound.

## Testing
Docs-only change; not run.