### PR TITLE
Add experiences maze and orb

### DIFF
--- a/dashboard/src/experiences/neural-maze-lock/NeuralMazeLock.tsx
+++ b/dashboard/src/experiences/neural-maze-lock/NeuralMazeLock.tsx
@@ -58,7 +58,8 @@ const MAZE = [
 
 const ROWS = MAZE.length;
 const COLS = MAZE[0].length;
-const CELL = 48;
+const MAX_CELL = 56;
+const MIN_CELL = 34;
 const FOCUS_THRESHOLD = 0.6;
 const CALM_THRESHOLD = 0.6;
 const MIN_CALIBRATION = 0.5;
@@ -304,6 +305,7 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
   const completedRef = useRef(false);
   const completionLoggedRef = useRef(false);
   const falseArmedRef = useRef(true);
+  const boardWrapRef = useRef<HTMLDivElement | null>(null);
   const startTimeRef = useRef<number | null>(null);
   const stepCooldownRef = useRef(0);
   const lastTickRef = useRef(performance.now());
@@ -327,6 +329,7 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
   const [eogResponse, setEogResponse] = useState(1);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsOpen, setControlsOpen] = useState(true);
+  const [cellSize, setCellSize] = useState(MAX_CELL);
 
   const log = useCallback((action: string, frame: SignalFrame, result?: string) => {
     setEntries((prev) =>
@@ -365,6 +368,30 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
     document.addEventListener("fullscreenchange", onFullscreenChange);
     return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
   }, []);
+
+  useEffect(() => {
+    const measureCellSize = () => {
+      const rect = boardWrapRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const fit = Math.floor(Math.min((rect.width - 24) / COLS, (rect.height - 24) / ROWS));
+      const next = clamp(fit, MIN_CELL, MAX_CELL);
+      setCellSize((current) => (current === next ? current : next));
+    };
+
+    const frame = requestAnimationFrame(measureCellSize);
+    const observer =
+      typeof ResizeObserver !== "undefined" && boardWrapRef.current
+        ? new ResizeObserver(measureCellSize)
+        : null;
+    if (boardWrapRef.current) observer?.observe(boardWrapRef.current);
+    window.addEventListener("resize", measureCellSize);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer?.disconnect();
+      window.removeEventListener("resize", measureCellSize);
+    };
+  }, [controlsOpen]);
 
   const toggleFullscreen = async () => {
     try {
@@ -571,6 +598,9 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
         const gate = gatesRef.current[k];
         const style: CSSProperties = {
           ...styles.cell,
+          width: cellSize,
+          height: cellSize,
+          fontSize: Math.max(9, Math.round(cellSize * 0.23)),
           ...(cell === "wall" ? styles.wall : styles.path),
           ...(cell === "exit" ? styles.exit : {}),
           ...(gate && !gate.open ? { borderColor: GATE_INFO[gate.type].color, color: GATE_INFO[gate.type].color } : {}),
@@ -585,7 +615,7 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
       }
     }
     return out;
-  }, [gateVersion, layout.base, targetKey]);
+  }, [cellSize, gateVersion, layout.base, targetKey]);
 
   const target = targetKey ? gatesRef.current[targetKey] : null;
   const targetInfo = target ? GATE_INFO[target.type] : null;
@@ -622,20 +652,22 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
         </section>
 
         <main style={{ ...styles.main, ...(controlsOpen ? {} : styles.mainControlsHidden) }}>
-          <div style={styles.boardWrap}>
+          <div ref={boardWrapRef} style={styles.boardWrap}>
             <div
               style={{
                 ...styles.board,
-                width: COLS * CELL,
-                height: ROWS * CELL,
-                gridTemplateColumns: `repeat(${COLS}, ${CELL}px)`,
+                width: COLS * cellSize,
+                height: ROWS * cellSize,
+                gridTemplateColumns: `repeat(${COLS}, ${cellSize}px)`,
               }}
             >
               {cells}
               <div
                 style={{
                   ...styles.player,
-                  transform: `translate(${player.c * CELL + 5}px, ${player.r * CELL + 5}px)`,
+                  width: cellSize - 12,
+                  height: cellSize - 12,
+                  transform: `translate(${player.c * cellSize + 5}px, ${player.r * cellSize + 5}px)`,
                 }}
               />
               {completeOverlay && <div style={styles.complete}>{completeOverlay}</div>}
@@ -715,18 +747,19 @@ const styles: Record<string, CSSProperties> = {
     position: "fixed",
     inset: 0,
     overflow: "auto",
+    overflowX: "hidden",
     background: "radial-gradient(circle at 20% 10%, #12324a 0, #07111f 38%, #030712 100%)",
     color: "#e5f7ff",
     fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
-    padding: 24,
+    padding: "clamp(12px, 2vw, 24px)",
   },
   appShell: {
-    width: "min(100%, 1260px)",
+    width: "min(100%, 1440px)",
     minHeight: "calc(100vh - 48px)",
     margin: "0 auto",
     display: "flex",
     flexDirection: "column",
-    gap: 18,
+    gap: 14,
   },
   exitButton: {
     position: "absolute",
@@ -753,20 +786,24 @@ const styles: Record<string, CSSProperties> = {
   headerActions: { display: "flex", gap: 10, alignItems: "center", justifyContent: "flex-end", flexWrap: "wrap" },
   main: {
     display: "grid",
-    gridTemplateColumns: "minmax(720px, 720px) 340px",
+    gridTemplateColumns: "minmax(0, 1fr) minmax(280px, 340px)",
     gap: 22,
     alignItems: "stretch",
     justifyContent: "center",
+    flex: "1 1 auto",
+    minHeight: 0,
     transition: "grid-template-columns 180ms ease",
   },
   mainControlsHidden: {
-    gridTemplateColumns: "minmax(720px, 880px) 0px",
+    gridTemplateColumns: "minmax(0, 1fr)",
     gap: 0,
   },
   boardWrap: {
     display: "grid",
     placeItems: "center",
-    minHeight: 560,
+    minHeight: "clamp(360px, calc(100vh - 310px), 660px)",
+    minWidth: 0,
+    overflow: "hidden",
     border: "1px solid rgba(103,232,249,0.16)",
     borderRadius: 8,
     background: "rgba(2,6,23,0.24)",
@@ -780,8 +817,8 @@ const styles: Record<string, CSSProperties> = {
     background: "rgba(2,6,23,0.72)",
   },
   cell: {
-    width: CELL,
-    height: CELL,
+    width: MAX_CELL,
+    height: MAX_CELL,
     display: "grid",
     placeItems: "center",
     fontSize: 13,
@@ -796,8 +833,8 @@ const styles: Record<string, CSSProperties> = {
   targeted: { boxShadow: "inset 0 0 0 2px #fff" },
   player: {
     position: "absolute",
-    width: CELL - 12,
-    height: CELL - 12,
+    width: MAX_CELL - 12,
+    height: MAX_CELL - 12,
     borderRadius: "50%",
     background: "linear-gradient(135deg, #fff, #67e8f9)",
     boxShadow: "0 0 24px rgba(103,232,249,0.9)",
@@ -824,14 +861,18 @@ const styles: Record<string, CSSProperties> = {
     alignSelf: "stretch",
     overflow: "hidden",
     opacity: 1,
+    minWidth: 0,
+    boxSizing: "border-box",
     transition: "opacity 160ms ease, transform 180ms ease, padding 180ms ease, border-width 180ms ease",
   },
   panelHidden: {
+    display: "none",
     opacity: 0,
-    transform: "translateX(18px)",
+    transform: "translateX(24px)",
     pointerEvents: "none",
     padding: 0,
     borderWidth: 0,
+    width: 0,
   },
   panelLabel: { color: "#67e8f9", fontSize: 12, textTransform: "uppercase", letterSpacing: 0 },
   gateTitle: { margin: "4px 0 8px", fontSize: 22 },
@@ -857,9 +898,10 @@ const styles: Record<string, CSSProperties> = {
   slider: { display: "grid", gap: 8, marginTop: 18, color: "#dbeafe", fontSize: 13 },
   metrics: {
     display: "grid",
-    gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+    gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
     gap: 10,
-    marginBottom: 6,
+    marginTop: "auto",
+    marginBottom: 0,
   },
   metric: {
     minHeight: 48,

--- a/dashboard/src/experiences/neural-maze-lock/NeuralMazeLock.tsx
+++ b/dashboard/src/experiences/neural-maze-lock/NeuralMazeLock.tsx
@@ -33,13 +33,13 @@ type GateRuntime = {
   startedAt: number;
 };
 
-type LogEntry = {
-  t: number;
-  action: string;
-  result?: string;
-  focus: number;
-  calm: number;
-  calibration: number;
+type MazeMetrics = {
+  gatesOpened: number;
+  attempts: number;
+  falseTriggers: number;
+  gateTimeTotal: number;
+  gateTimeCount: number;
+  mazeTime: number | null;
 };
 
 const MAZE = [
@@ -128,6 +128,17 @@ function freshGates(gates: Record<string, GateType>) {
     };
   }
   return out;
+}
+
+function freshMetrics(): MazeMetrics {
+  return {
+    gatesOpened: 0,
+    attempts: 0,
+    falseTriggers: 0,
+    gateTimeTotal: 0,
+    gateTimeCount: 0,
+    mazeTime: null,
+  };
 }
 
 function readEog(eegData: EEGData, sampleRate: number, response: number) {
@@ -229,30 +240,17 @@ function useKeyboardGaze(onExit: () => void) {
   return { keysRef, mockRef };
 }
 
-function Metrics({ entries }: { entries: LogEntry[] }) {
-  const gatesOpened = entries.filter((e) => e.action === "gate_opened").length;
-  const attempts = entries.filter((e) => e.action === "gate_charge_started").length;
-  const falseTriggers = entries.filter((e) => e.action === "false_trigger").length;
-  const times = entries
-    .filter((e) => e.action === "gate_opened")
-    .map((e) => Number.parseFloat(e.result ?? ""))
-    .filter(Number.isFinite);
-  const completions = entries
-    .filter((e) => e.action === "maze_completed")
-    .map((e) => Number.parseFloat(e.result ?? ""))
-    .filter(Number.isFinite);
-  const completion = completions.length ? completions[completions.length - 1] : null;
-
+function Metrics({ metrics }: { metrics: MazeMetrics }) {
   return (
     <div style={styles.metrics}>
-      <Metric label="Gates" value={`${gatesOpened}/4`} />
-      <Metric label="Attempts" value={String(attempts)} />
-      <Metric label="False triggers" value={String(falseTriggers)} />
+      <Metric label="Gates" value={`${metrics.gatesOpened}/4`} />
+      <Metric label="Attempts" value={String(metrics.attempts)} />
+      <Metric label="False triggers" value={String(metrics.falseTriggers)} />
       <Metric
         label="Avg gate"
-        value={times.length ? `${(times.reduce((a, b) => a + b, 0) / times.length).toFixed(1)}s` : "-"}
+        value={metrics.gateTimeCount ? `${(metrics.gateTimeTotal / metrics.gateTimeCount).toFixed(1)}s` : "-"}
       />
-      <Metric label="Maze time" value={completion ? `${completion.toFixed(1)}s` : "-"} />
+      <Metric label="Maze time" value={metrics.mazeTime !== null ? `${metrics.mazeTime.toFixed(1)}s` : "-"} />
     </div>
   );
 }
@@ -325,26 +323,28 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
     gazeX: 0,
     gazeY: 0,
   });
-  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [metrics, setMetrics] = useState<MazeMetrics>(freshMetrics);
   const [eogResponse, setEogResponse] = useState(1);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsOpen, setControlsOpen] = useState(true);
   const [cellSize, setCellSize] = useState(MAX_CELL);
 
-  const log = useCallback((action: string, frame: SignalFrame, result?: string) => {
-    setEntries((prev) =>
-      [
-        ...prev,
-        {
-          t: Date.now(),
-          action,
-          result,
-          focus: frame.focus,
-          calm: frame.calm,
-          calibration: frame.calibration,
-        },
-      ].slice(-200),
-    );
+  const log = useCallback((action: string, _frame: SignalFrame, result?: string) => {
+    setMetrics((prev) => {
+      if (action === "gate_charge_started") return { ...prev, attempts: prev.attempts + 1 };
+      if (action === "false_trigger") return { ...prev, falseTriggers: prev.falseTriggers + 1 };
+      if (action === "maze_completed") return { ...prev, mazeTime: Number.parseFloat(result ?? "") };
+      if (action === "gate_opened") {
+        const gateTime = Number.parseFloat(result ?? "");
+        return {
+          ...prev,
+          gatesOpened: prev.gatesOpened + 1,
+          gateTimeTotal: Number.isFinite(gateTime) ? prev.gateTimeTotal + gateTime : prev.gateTimeTotal,
+          gateTimeCount: Number.isFinite(gateTime) ? prev.gateTimeCount + 1 : prev.gateTimeCount,
+        };
+      }
+      return prev;
+    });
   }, []);
 
   const resetMaze = useCallback(() => {
@@ -360,6 +360,7 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
     setTargetKey(null);
     setTargetCharge(0);
     setTargetReady(false);
+    setMetrics(freshMetrics());
     setGateVersion((v) => v + 1);
   }, [layout]);
 
@@ -726,7 +727,7 @@ export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
           </aside>
         </main>
 
-        <Metrics entries={entries} />
+        <Metrics metrics={metrics} />
       </div>
 
       {phase === "calibrating" && (

--- a/dashboard/src/experiences/neural-maze-lock/NeuralMazeLock.tsx
+++ b/dashboard/src/experiences/neural-maze-lock/NeuralMazeLock.tsx
@@ -1,0 +1,911 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import type { ExperienceProps } from "../registry";
+import type { EEGData } from "../../types";
+import { useBlink, useFocus, useRelax } from "../../hooks/detectors";
+import { useSampleRate } from "../../lib/sampleRateStore";
+
+type GateType = "focus" | "calm" | "blink";
+type Cell = "wall" | "path" | "start" | "exit" | "gate";
+type Phase = "calibrating" | "playing";
+
+type SignalFrame = {
+  focus: number;
+  calm: number;
+  blink: boolean;
+  calibration: number;
+  gazeX: number;
+  gazeY: number;
+};
+
+type MockSignalControls = {
+  focus: number;
+  calm: number;
+  blink: boolean;
+};
+
+type GateRuntime = {
+  type: GateType;
+  open: boolean;
+  charge: number;
+  charging: boolean;
+  ready: boolean;
+  startedAt: number;
+};
+
+type LogEntry = {
+  t: number;
+  action: string;
+  result?: string;
+  focus: number;
+  calm: number;
+  calibration: number;
+};
+
+const MAZE = [
+  "###############",
+  "#S            #",
+  "#############F#",
+  "#             #",
+  "#C#############",
+  "#             #",
+  "#############B#",
+  "#             #",
+  "#F#############",
+  "#            E#",
+  "###############",
+];
+
+const ROWS = MAZE.length;
+const COLS = MAZE[0].length;
+const CELL = 48;
+const FOCUS_THRESHOLD = 0.6;
+const CALM_THRESHOLD = 0.6;
+const MIN_CALIBRATION = 0.5;
+const HOLD_TIME = 2;
+const DECAY_MULT = 0.5;
+const STEP_COOLDOWN = 0.16;
+const GAZE_DEADZONE = 0.45;
+
+const GATE_INFO: Record<GateType, { label: string; hint: string; color: string }> = {
+  focus: {
+    label: "Focus Gate",
+    hint: "Hold focus above threshold for two seconds.",
+    color: "#67e8f9",
+  },
+  calm: {
+    label: "Calm Gate",
+    hint: "Stay relaxed until the lock fills.",
+    color: "#86efac",
+  },
+  blink: {
+    label: "Blink Gate",
+    hint: "Two steps: hold focus until charged, then blink to confirm.",
+    color: "#f0abfc",
+  },
+};
+
+const keyOf = (r: number, c: number) => `${r},${c}`;
+const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+const pct = (v: number) => `${Math.round(clamp(v, 0, 1) * 100)}%`;
+
+function parseLayout() {
+  const base: Cell[][] = [];
+  const gates: Record<string, GateType> = {};
+  let start = { r: 1, c: 1 };
+
+  for (let r = 0; r < ROWS; r++) {
+    const row: Cell[] = [];
+    for (let c = 0; c < COLS; c++) {
+      const ch = MAZE[r][c];
+      if (ch === "#") row.push("wall");
+      else if (ch === "S") {
+        row.push("start");
+        start = { r, c };
+      } else if (ch === "E") row.push("exit");
+      else if (ch === "F" || ch === "C" || ch === "B") {
+        row.push("gate");
+        gates[keyOf(r, c)] = ch === "F" ? "focus" : ch === "C" ? "calm" : "blink";
+      } else row.push("path");
+    }
+    base.push(row);
+  }
+
+  return { base, gates, start };
+}
+
+function freshGates(gates: Record<string, GateType>) {
+  const out: Record<string, GateRuntime> = {};
+  for (const k of Object.keys(gates)) {
+    out[k] = {
+      type: gates[k],
+      open: false,
+      charge: 0,
+      charging: false,
+      ready: false,
+      startedAt: 0,
+    };
+  }
+  return out;
+}
+
+function readEog(eegData: EEGData, sampleRate: number, response: number) {
+  const buffers = eegData.buffers.current;
+  if (buffers.length < 2) return { x: 0, y: 0 };
+
+  const windowSamples = Math.max(8, Math.round(sampleRate * 0.12));
+  if (eegData.samplesInBuffer.current < windowSamples) return { x: 0, y: 0 };
+
+  const fp1 = buffers[0];
+  const fp2 = buffers[1];
+  const wi = eegData.writeIndex.current;
+  const bs = eegData.bufferSize;
+  let sumH = 0;
+  let sumV = 0;
+
+  for (let i = 0; i < windowSamples; i++) {
+    const idx = (wi - windowSamples + i + bs) % bs;
+    const v1 = fp1[idx] ?? 0;
+    const v2 = fp2[idx] ?? 0;
+    sumH += v2 - v1;
+    sumV += (v1 + v2) * 0.5;
+  }
+
+  const scale = 120 / Math.max(0.25, response);
+  return {
+    x: clamp(sumH / windowSamples / scale, -1, 1),
+    y: clamp(-(sumV / windowSamples / scale), -1, 1),
+  };
+}
+
+function useKeyboardGaze(onExit: () => void) {
+  const keysRef = useRef({ up: false, down: false, left: false, right: false });
+  const mockRef = useRef<MockSignalControls>({
+    focus: 0,
+    calm: 0,
+    blink: false,
+  });
+  const blinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const dirOf = (key: string): keyof typeof keysRef.current | null => {
+      switch (key.toLowerCase()) {
+        case "arrowup":
+        case "w":
+          return "up";
+        case "arrowdown":
+        case "s":
+          return "down";
+        case "arrowleft":
+        case "a":
+          return "left";
+        case "arrowright":
+        case "d":
+          return "right";
+        default:
+          return null;
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onExit();
+      const dir = dirOf(e.key);
+      if (dir) {
+        e.preventDefault();
+        keysRef.current[dir] = true;
+        return;
+      }
+
+      if (e.repeat) return;
+      const key = e.key.toLowerCase();
+      const mock = mockRef.current;
+      if (key === "f") mock.focus = clamp(mock.focus + 0.15, 0, 1);
+      else if (key === "r") mock.focus = clamp(mock.focus - 0.15, 0, 1);
+      else if (key === "c") mock.calm = clamp(mock.calm + 0.15, 0, 1);
+      else if (key === "x") mock.calm = clamp(mock.calm - 0.15, 0, 1);
+      else if (key === "b") {
+        mock.blink = true;
+        if (blinkTimerRef.current) clearTimeout(blinkTimerRef.current);
+        blinkTimerRef.current = setTimeout(() => {
+          mockRef.current.blink = false;
+        }, 180);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      const dir = dirOf(e.key);
+      if (dir) keysRef.current[dir] = false;
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      if (blinkTimerRef.current) clearTimeout(blinkTimerRef.current);
+    };
+  }, [onExit]);
+
+  return { keysRef, mockRef };
+}
+
+function Metrics({ entries }: { entries: LogEntry[] }) {
+  const gatesOpened = entries.filter((e) => e.action === "gate_opened").length;
+  const attempts = entries.filter((e) => e.action === "gate_charge_started").length;
+  const falseTriggers = entries.filter((e) => e.action === "false_trigger").length;
+  const times = entries
+    .filter((e) => e.action === "gate_opened")
+    .map((e) => Number.parseFloat(e.result ?? ""))
+    .filter(Number.isFinite);
+  const completions = entries
+    .filter((e) => e.action === "maze_completed")
+    .map((e) => Number.parseFloat(e.result ?? ""))
+    .filter(Number.isFinite);
+  const completion = completions.length ? completions[completions.length - 1] : null;
+
+  return (
+    <div style={styles.metrics}>
+      <Metric label="Gates" value={`${gatesOpened}/4`} />
+      <Metric label="Attempts" value={String(attempts)} />
+      <Metric label="False triggers" value={String(falseTriggers)} />
+      <Metric
+        label="Avg gate"
+        value={times.length ? `${(times.reduce((a, b) => a + b, 0) / times.length).toFixed(1)}s` : "-"}
+      />
+      <Metric label="Maze time" value={completion ? `${completion.toFixed(1)}s` : "-"} />
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={styles.metric}>
+      <span style={styles.metricLabel}>{label}</span>
+      <span style={styles.metricValue}>{value}</span>
+    </div>
+  );
+}
+
+function Meter({
+  label,
+  value,
+  color,
+  threshold,
+}: {
+  label: string;
+  value: number;
+  color: string;
+  threshold?: number;
+}) {
+  return (
+    <div style={styles.meter}>
+      <div style={styles.meterTop}>
+        <span>{label}</span>
+        <span>{pct(value)}</span>
+      </div>
+      <div style={styles.track}>
+        {threshold !== undefined && <span style={{ ...styles.tick, left: pct(threshold) }} />}
+        <span style={{ ...styles.fill, width: pct(value), background: color }} />
+      </div>
+    </div>
+  );
+}
+
+export default function NeuralMazeLock({ eegData, onExit }: ExperienceProps) {
+  const sampleRate = useSampleRate();
+  const { state: focusState, calibrate: calibrateFocus } = useFocus(eegData);
+  const { state: relaxState, calibrate: calibrateRelax } = useRelax(eegData);
+  const { state: blinkState } = useBlink(eegData);
+  const { keysRef, mockRef } = useKeyboardGaze(onExit);
+
+  const layout = useMemo(parseLayout, []);
+  const gatesRef = useRef(freshGates(layout.gates));
+  const playerRef = useRef(layout.start);
+  const phaseRef = useRef<Phase>("calibrating");
+  const completedRef = useRef(false);
+  const completionLoggedRef = useRef(false);
+  const falseArmedRef = useRef(true);
+  const startTimeRef = useRef<number | null>(null);
+  const stepCooldownRef = useRef(0);
+  const lastTickRef = useRef(performance.now());
+
+  const [phase, setPhase] = useState<Phase>("calibrating");
+  const [player, setPlayer] = useState(layout.start);
+  const [gateVersion, setGateVersion] = useState(0);
+  const [targetKey, setTargetKey] = useState<string | null>(null);
+  const [targetCharge, setTargetCharge] = useState(0);
+  const [targetReady, setTargetReady] = useState(false);
+  const [completed, setCompleted] = useState(false);
+  const [signal, setSignal] = useState<SignalFrame>({
+    focus: 0,
+    calm: 0,
+    blink: false,
+    calibration: 0,
+    gazeX: 0,
+    gazeY: 0,
+  });
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [eogResponse, setEogResponse] = useState(1);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [controlsOpen, setControlsOpen] = useState(true);
+
+  const log = useCallback((action: string, frame: SignalFrame, result?: string) => {
+    setEntries((prev) =>
+      [
+        ...prev,
+        {
+          t: Date.now(),
+          action,
+          result,
+          focus: frame.focus,
+          calm: frame.calm,
+          calibration: frame.calibration,
+        },
+      ].slice(-200),
+    );
+  }, []);
+
+  const resetMaze = useCallback(() => {
+    gatesRef.current = freshGates(layout.gates);
+    playerRef.current = layout.start;
+    completedRef.current = false;
+    completionLoggedRef.current = false;
+    falseArmedRef.current = true;
+    startTimeRef.current = null;
+    stepCooldownRef.current = 0;
+    setPlayer(layout.start);
+    setCompleted(false);
+    setTargetKey(null);
+    setTargetCharge(0);
+    setTargetReady(false);
+    setGateVersion((v) => v + 1);
+  }, [layout]);
+
+  useEffect(() => {
+    const onFullscreenChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = async () => {
+    try {
+      if (document.fullscreenElement) await document.exitFullscreen();
+      else await document.documentElement.requestFullscreen();
+    } catch {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([calibrateFocus(), calibrateRelax()]).finally(() => {
+      if (!cancelled) {
+        phaseRef.current = "playing";
+        setPhase("playing");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [calibrateFocus, calibrateRelax]);
+
+  const startAnyway = () => {
+    phaseRef.current = "playing";
+    setPhase("playing");
+  };
+
+  useEffect(() => {
+    let raf = 0;
+
+    const passable = (r: number, c: number) => {
+      if (r < 0 || c < 0 || r >= ROWS || c >= COLS) return false;
+      const cell = layout.base[r][c];
+      if (cell === "wall") return false;
+      if (cell === "gate") return gatesRef.current[keyOf(r, c)]?.open ?? false;
+      return true;
+    };
+
+    const stepPlayer = (dr: number, dc: number) => {
+      if (completedRef.current) return false;
+      const { r, c } = playerRef.current;
+      const nr = r + dr;
+      const nc = c + dc;
+      if (!passable(nr, nc)) return false;
+      const next = { r: nr, c: nc };
+      playerRef.current = next;
+      setPlayer(next);
+      if (startTimeRef.current === null) startTimeRef.current = Date.now();
+      if (layout.base[nr][nc] === "exit") {
+        completedRef.current = true;
+        setCompleted(true);
+      }
+      return true;
+    };
+
+    const loop = () => {
+      const now = performance.now();
+      const dt = Math.min((now - lastTickRef.current) / 1000, 0.1);
+      lastTickRef.current = now;
+
+      const eog = readEog(eegData, sampleRate, eogResponse);
+      const keys = keysRef.current;
+      const mock = mockRef.current;
+      const keyGaze = {
+        x: (keys.right ? 1 : 0) - (keys.left ? 1 : 0),
+        y: (keys.up ? 1 : 0) - (keys.down ? 1 : 0),
+      };
+      const hasKeys = keyGaze.x !== 0 || keyGaze.y !== 0;
+      const hasEog = Math.abs(eog.x) > 0.05 || Math.abs(eog.y) > 0.05;
+      const frame: SignalFrame = {
+        focus: Math.max(focusState.current.focus, mock.focus),
+        calm: Math.max(relaxState.current.relaxation, mock.calm),
+        blink: blinkState.current.blinked || mock.blink,
+        calibration:
+          focusState.current.calibrated || relaxState.current.calibrated || phaseRef.current === "playing"
+            ? 1
+            : 0.15,
+        gazeX: hasKeys ? keyGaze.x : hasEog ? eog.x : 0,
+        gazeY: hasKeys ? keyGaze.y : hasEog ? eog.y : 0,
+      };
+      setSignal(frame);
+
+      if (phaseRef.current !== "playing") {
+        raf = requestAnimationFrame(loop);
+        return;
+      }
+
+      if (stepCooldownRef.current > 0) stepCooldownRef.current -= dt;
+      if (!completedRef.current && stepCooldownRef.current <= 0) {
+        const gx = frame.gazeX;
+        const gy = frame.gazeY;
+        if (Math.abs(gx) > GAZE_DEADZONE || Math.abs(gy) > GAZE_DEADZONE) {
+          let dr = 0;
+          let dc = 0;
+          if (Math.abs(gx) >= Math.abs(gy)) dc = gx > 0 ? 1 : -1;
+          else dr = gy > 0 ? -1 : 1;
+          if (stepPlayer(dr, dc)) stepCooldownRef.current = STEP_COOLDOWN;
+        }
+      }
+
+      const { r, c } = playerRef.current;
+      let nextTarget: string | null = null;
+      for (const [dr, dc] of [
+        [-1, 0],
+        [1, 0],
+        [0, -1],
+        [0, 1],
+      ]) {
+        const k = keyOf(r + dr, c + dc);
+        const gate = gatesRef.current[k];
+        if (gate && !gate.open) {
+          nextTarget = k;
+          break;
+        }
+      }
+      setTargetKey(nextTarget);
+
+      if (completedRef.current) {
+        if (!completionLoggedRef.current) {
+          completionLoggedRef.current = true;
+          const elapsed = (Date.now() - (startTimeRef.current ?? Date.now())) / 1000;
+          log("maze_completed", frame, elapsed.toFixed(2));
+        }
+        setTargetCharge(0);
+        setTargetReady(false);
+        raf = requestAnimationFrame(loop);
+        return;
+      }
+
+      const calibrationOk = frame.calibration > MIN_CALIBRATION;
+      if (nextTarget) {
+        const gate = gatesRef.current[nextTarget];
+        const meets = gate.type === "calm" ? frame.calm > CALM_THRESHOLD : frame.focus > FOCUS_THRESHOLD;
+        if (meets && calibrationOk) {
+          if (!gate.charging) {
+            gate.charging = true;
+            gate.startedAt = Date.now();
+            log("gate_charge_started", frame, gate.type);
+          }
+          gate.charge = Math.min(1, gate.charge + dt / HOLD_TIME);
+          if (gate.charge >= 1) {
+            if (gate.type === "blink") {
+              gate.ready = true;
+              if (frame.blink) openGate(gate, frame);
+            } else openGate(gate, frame);
+          }
+        } else {
+          const wasCharging = gate.charging;
+          gate.charge = Math.max(0, gate.charge - (dt / HOLD_TIME) * DECAY_MULT);
+          if (wasCharging && gate.charge <= 0) {
+            gate.charging = false;
+            gate.ready = false;
+            log("gate_charge_decayed", frame, "attempt lapsed");
+          }
+        }
+        setTargetCharge(gate.charge);
+        setTargetReady(gate.ready);
+      } else {
+        if (frame.focus > FOCUS_THRESHOLD && calibrationOk) {
+          if (falseArmedRef.current) {
+            falseArmedRef.current = false;
+            log("false_trigger", frame, "focus high with no gate targeted");
+          }
+        } else if (frame.focus <= FOCUS_THRESHOLD) falseArmedRef.current = true;
+        setTargetCharge(0);
+        setTargetReady(false);
+      }
+
+      raf = requestAnimationFrame(loop);
+    };
+
+    const openGate = (gate: GateRuntime, frame: SignalFrame) => {
+      if (gate.open) return;
+      gate.open = true;
+      gate.charging = false;
+      gate.ready = false;
+      gate.charge = 1;
+      const elapsed = (Date.now() - gate.startedAt) / 1000;
+      log("gate_opened", frame, `${elapsed.toFixed(2)} ${gate.type}`);
+      setGateVersion((v) => v + 1);
+    };
+
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [
+    blinkState,
+    eegData,
+    eogResponse,
+    focusState,
+    keysRef,
+    layout,
+    log,
+    relaxState,
+    sampleRate,
+  ]);
+
+  const cells = useMemo(() => {
+    const out = [];
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const cell = layout.base[r][c];
+        const k = keyOf(r, c);
+        const gate = gatesRef.current[k];
+        const style: CSSProperties = {
+          ...styles.cell,
+          ...(cell === "wall" ? styles.wall : styles.path),
+          ...(cell === "exit" ? styles.exit : {}),
+          ...(gate && !gate.open ? { borderColor: GATE_INFO[gate.type].color, color: GATE_INFO[gate.type].color } : {}),
+          ...(gate?.open ? styles.openGate : {}),
+          ...(k === targetKey ? styles.targeted : {}),
+        };
+        out.push(
+          <div key={k} style={style}>
+            {gate && !gate.open ? gate.type[0].toUpperCase() : cell === "exit" ? "EXIT" : ""}
+          </div>,
+        );
+      }
+    }
+    return out;
+  }, [gateVersion, layout.base, targetKey]);
+
+  const target = targetKey ? gatesRef.current[targetKey] : null;
+  const targetInfo = target ? GATE_INFO[target.type] : null;
+  const completeOverlay = completed ? "Maze cleared. All neural locks opened." : null;
+  const blinkGateStep =
+    target?.type === "blink"
+      ? targetReady
+        ? "Step 2: blink now to open the gate."
+        : "Step 1: hold focus until the charge reaches 100%."
+      : null;
+
+  return (
+    <div style={styles.root}>
+      <button onClick={onExit} style={styles.exitButton}>Exit</button>
+      <div style={styles.appShell}>
+        <section style={styles.header}>
+          <div>
+            <div style={styles.eyebrow}>BCI / EOG game</div>
+            <h1 style={styles.title}>Neural Maze Lock</h1>
+            <p style={styles.subtitle}>
+              Navigate by EOG gaze or WASD/arrow fallback. Focus, calm, and blink gates test
+              neural intent-confirmation and false-trigger behavior.
+            </p>
+          </div>
+          <div style={styles.headerActions}>
+            <button onClick={() => setControlsOpen((open) => !open)} style={styles.secondaryButton}>
+              {controlsOpen ? "Hide controls" : "Show controls"}
+            </button>
+            <button onClick={toggleFullscreen} style={styles.secondaryButton}>
+              {isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            </button>
+            <button onClick={resetMaze} style={styles.secondaryButton}>Reset maze</button>
+          </div>
+        </section>
+
+        <main style={{ ...styles.main, ...(controlsOpen ? {} : styles.mainControlsHidden) }}>
+          <div style={styles.boardWrap}>
+            <div
+              style={{
+                ...styles.board,
+                width: COLS * CELL,
+                height: ROWS * CELL,
+                gridTemplateColumns: `repeat(${COLS}, ${CELL}px)`,
+              }}
+            >
+              {cells}
+              <div
+                style={{
+                  ...styles.player,
+                  transform: `translate(${player.c * CELL + 5}px, ${player.r * CELL + 5}px)`,
+                }}
+              />
+              {completeOverlay && <div style={styles.complete}>{completeOverlay}</div>}
+            </div>
+          </div>
+
+          <aside style={{ ...styles.panel, ...(controlsOpen ? {} : styles.panelHidden) }} aria-hidden={!controlsOpen}>
+            {target && targetInfo ? (
+              <>
+                <div style={styles.panelLabel}>Targeted gate</div>
+                <h2 style={{ ...styles.gateTitle, color: targetInfo.color }}>{targetInfo.label}</h2>
+                <p style={styles.hint}>{targetInfo.hint}</p>
+                {blinkGateStep && <p style={styles.stepHint}>{blinkGateStep}</p>}
+                <p style={styles.hint}>Mock controls: F/R focus, C/X calm, B blink.</p>
+                <div style={styles.chargeShell}>
+                  <div
+                    style={{
+                      ...styles.chargeFill,
+                      width: pct(targetCharge),
+                      background: targetInfo.color,
+                    }}
+                  />
+                </div>
+                <div style={styles.statusLine}>
+                  {target?.type === "blink" && targetReady
+                    ? "Ready: press B or blink deliberately."
+                    : `Charge ${pct(targetCharge)}`}
+                </div>
+              </>
+            ) : (
+              <>
+                <div style={styles.panelLabel}>Gate console</div>
+                <h2 style={styles.gateTitle}>Navigate to a lock</h2>
+                <p style={styles.hint}>Raising focus away from a gate increments the false-trigger metric.</p>
+                <p style={styles.hint}>Mock controls: F/R focus, C/X calm, B blink.</p>
+              </>
+            )}
+
+            <Meter label="Focus" value={signal.focus} threshold={FOCUS_THRESHOLD} color="#67e8f9" />
+            <Meter label="Calm" value={signal.calm} threshold={CALM_THRESHOLD} color="#86efac" />
+            <Meter label="Calibration" value={signal.calibration} threshold={MIN_CALIBRATION} color="#facc15" />
+            <Meter label="Gaze X" value={(signal.gazeX + 1) / 2} color="#f0abfc" />
+            <Meter label="Gaze Y" value={(signal.gazeY + 1) / 2} color="#f0abfc" />
+
+            <label style={styles.slider}>
+              <span>EOG response {eogResponse.toFixed(1)}x</span>
+              <input
+                type="range"
+                min={0.5}
+                max={3}
+                step={0.1}
+                value={eogResponse}
+                onChange={(e) => setEogResponse(Number(e.currentTarget.value))}
+              />
+            </label>
+          </aside>
+        </main>
+
+        <Metrics entries={entries} />
+      </div>
+
+      {phase === "calibrating" && (
+        <div style={styles.overlay}>
+          <div style={styles.overlayCard}>
+            <h2 style={styles.overlayTitle}>Calibrating baseline</h2>
+            <p style={styles.hint}>Sit still for about three seconds while focus and relaxation baselines warm up.</p>
+            <button onClick={startAnyway} style={styles.primaryButton}>Start anyway</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  root: {
+    position: "fixed",
+    inset: 0,
+    overflow: "auto",
+    background: "radial-gradient(circle at 20% 10%, #12324a 0, #07111f 38%, #030712 100%)",
+    color: "#e5f7ff",
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+    padding: 24,
+  },
+  appShell: {
+    width: "min(100%, 1260px)",
+    minHeight: "calc(100vh - 48px)",
+    margin: "0 auto",
+    display: "flex",
+    flexDirection: "column",
+    gap: 18,
+  },
+  exitButton: {
+    position: "absolute",
+    top: 16,
+    left: 16,
+    zIndex: 5,
+    border: "1px solid rgba(255,255,255,0.22)",
+    background: "rgba(2,6,23,0.72)",
+    color: "#e5f7ff",
+    borderRadius: 6,
+    padding: "8px 12px",
+    cursor: "pointer",
+  },
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 16,
+    alignItems: "flex-start",
+    margin: "8px 0 0 72px",
+  },
+  eyebrow: { color: "#67e8f9", fontSize: 12, textTransform: "uppercase", letterSpacing: 0 },
+  title: { margin: "2px 0 4px", fontSize: 34, lineHeight: 1.05 },
+  subtitle: { maxWidth: 760, margin: 0, color: "#a8c7d8", lineHeight: 1.45 },
+  headerActions: { display: "flex", gap: 10, alignItems: "center", justifyContent: "flex-end", flexWrap: "wrap" },
+  main: {
+    display: "grid",
+    gridTemplateColumns: "minmax(720px, 720px) 340px",
+    gap: 22,
+    alignItems: "stretch",
+    justifyContent: "center",
+    transition: "grid-template-columns 180ms ease",
+  },
+  mainControlsHidden: {
+    gridTemplateColumns: "minmax(720px, 880px) 0px",
+    gap: 0,
+  },
+  boardWrap: {
+    display: "grid",
+    placeItems: "center",
+    minHeight: 560,
+    border: "1px solid rgba(103,232,249,0.16)",
+    borderRadius: 8,
+    background: "rgba(2,6,23,0.24)",
+  },
+  board: {
+    position: "relative",
+    display: "grid",
+    gap: 0,
+    border: "1px solid rgba(103,232,249,0.3)",
+    boxShadow: "0 0 50px rgba(34,211,238,0.16)",
+    background: "rgba(2,6,23,0.72)",
+  },
+  cell: {
+    width: CELL,
+    height: CELL,
+    display: "grid",
+    placeItems: "center",
+    fontSize: 13,
+    fontWeight: 800,
+    border: "1px solid rgba(148,163,184,0.14)",
+    boxSizing: "border-box",
+  },
+  wall: { background: "#101827" },
+  path: { background: "rgba(15,23,42,0.48)" },
+  exit: { color: "#bbf7d0", fontSize: 9, background: "rgba(20,83,45,0.34)" },
+  openGate: { background: "rgba(34,197,94,0.16)", borderColor: "rgba(134,239,172,0.35)" },
+  targeted: { boxShadow: "inset 0 0 0 2px #fff" },
+  player: {
+    position: "absolute",
+    width: CELL - 12,
+    height: CELL - 12,
+    borderRadius: "50%",
+    background: "linear-gradient(135deg, #fff, #67e8f9)",
+    boxShadow: "0 0 24px rgba(103,232,249,0.9)",
+    transition: "transform 120ms linear",
+  },
+  complete: {
+    position: "absolute",
+    inset: "34% 14%",
+    display: "grid",
+    placeItems: "center",
+    textAlign: "center",
+    background: "rgba(2,6,23,0.88)",
+    border: "1px solid rgba(134,239,172,0.45)",
+    borderRadius: 8,
+    color: "#bbf7d0",
+    fontWeight: 800,
+  },
+  panel: {
+    background: "rgba(2,6,23,0.72)",
+    border: "1px solid rgba(148,163,184,0.22)",
+    borderRadius: 8,
+    padding: 18,
+    boxShadow: "0 18px 60px rgba(0,0,0,0.28)",
+    alignSelf: "stretch",
+    overflow: "hidden",
+    opacity: 1,
+    transition: "opacity 160ms ease, transform 180ms ease, padding 180ms ease, border-width 180ms ease",
+  },
+  panelHidden: {
+    opacity: 0,
+    transform: "translateX(18px)",
+    pointerEvents: "none",
+    padding: 0,
+    borderWidth: 0,
+  },
+  panelLabel: { color: "#67e8f9", fontSize: 12, textTransform: "uppercase", letterSpacing: 0 },
+  gateTitle: { margin: "4px 0 8px", fontSize: 22 },
+  hint: { margin: "0 0 14px", color: "#a8c7d8", lineHeight: 1.45 },
+  stepHint: {
+    margin: "0 0 14px",
+    color: "#fff7ed",
+    lineHeight: 1.45,
+    border: "1px solid rgba(251,191,36,0.3)",
+    background: "rgba(251,191,36,0.1)",
+    borderRadius: 6,
+    padding: "8px 10px",
+    fontWeight: 700,
+  },
+  chargeShell: { height: 12, background: "rgba(148,163,184,0.18)", borderRadius: 999, overflow: "hidden" },
+  chargeFill: { height: "100%", transition: "width 100ms linear" },
+  statusLine: { marginTop: 8, color: "#dbeafe", fontSize: 13 },
+  meter: { marginTop: 14 },
+  meterTop: { display: "flex", justifyContent: "space-between", fontSize: 12, color: "#dbeafe", marginBottom: 5 },
+  track: { position: "relative", height: 8, borderRadius: 999, background: "rgba(148,163,184,0.2)", overflow: "hidden" },
+  fill: { display: "block", height: "100%", borderRadius: 999, transition: "width 100ms linear" },
+  tick: { position: "absolute", top: 0, bottom: 0, width: 2, background: "#fff", opacity: 0.7, zIndex: 1 },
+  slider: { display: "grid", gap: 8, marginTop: 18, color: "#dbeafe", fontSize: 13 },
+  metrics: {
+    display: "grid",
+    gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+    gap: 10,
+    marginBottom: 6,
+  },
+  metric: {
+    minHeight: 48,
+    padding: "10px 12px",
+    background: "rgba(2,6,23,0.72)",
+    border: "1px solid rgba(148,163,184,0.2)",
+    borderRadius: 8,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  metricValue: { display: "block", fontSize: 20, fontWeight: 800, color: "#e5f7ff" },
+  metricLabel: { display: "block", color: "#a8c7d8", fontSize: 12, textTransform: "uppercase", letterSpacing: 0 },
+  secondaryButton: {
+    border: "1px solid rgba(255,255,255,0.22)",
+    background: "rgba(15,23,42,0.85)",
+    color: "#e5f7ff",
+    borderRadius: 6,
+    padding: "10px 14px",
+    cursor: "pointer",
+  },
+  overlay: {
+    position: "absolute",
+    inset: 0,
+    display: "grid",
+    placeItems: "center",
+    background: "rgba(2,6,23,0.76)",
+    zIndex: 10,
+  },
+  overlayCard: {
+    width: "min(420px, calc(100vw - 40px))",
+    borderRadius: 8,
+    border: "1px solid rgba(103,232,249,0.36)",
+    padding: 22,
+    background: "#07111f",
+    boxShadow: "0 24px 80px rgba(0,0,0,0.42)",
+  },
+  overlayTitle: { margin: "0 0 8px", fontSize: 24 },
+  primaryButton: {
+    border: 0,
+    background: "#67e8f9",
+    color: "#06121f",
+    borderRadius: 6,
+    padding: "10px 14px",
+    fontWeight: 800,
+    cursor: "pointer",
+  },
+};

--- a/dashboard/src/experiences/neural-maze-lock/README.md
+++ b/dashboard/src/experiences/neural-maze-lock/README.md
@@ -1,0 +1,47 @@
+# Neural Maze Lock
+
+Neural Maze Lock is a playable BCI/EOG maze for the PiEEG dashboard experiences
+gallery. The player moves through a fixed serpentine maze using EOG gaze
+direction from Fp1/Fp2, with WASD/arrow keys as a mock-mode fallback.
+
+The maze is blocked by three neural lock types:
+
+| Gate | Opens when |
+| --- | --- |
+| Focus | focus stays above 0.6 for two seconds |
+| Calm | relaxation stays above 0.6 for two seconds |
+| Blink | focus charges the lock to 100%, then a blink confirms |
+
+The main research signal is false-trigger behavior. When focus rises while the
+player is not adjacent to a gate, the experience logs a false trigger. This
+tests whether neural signals can work as a reliable intent-confirmation layer in
+spatial computing.
+
+## PiEEG integration
+
+- Uses `useFocus(eegData)` for cortical engagement.
+- Uses `useRelax(eegData)` for alpha/theta relaxation.
+- Uses `useBlink(eegData)` for deliberate blink confirmation.
+- Reads raw EOG from `eegData.buffers.current[0]` and `[1]`:
+  - horizontal = `Fp2 - Fp1`
+  - vertical = `(Fp1 + Fp2) / 2`
+- Includes an EOG response slider because mock mode and real devices may have
+  different amplitudes. Higher response means stronger gaze movement.
+- Includes keyboard fallback for local testing without EOG-like mock samples.
+- Includes mock signal keys for local testing because PiEEG mock mode does not
+  provide per-experience sliders.
+
+## Controls
+
+- WASD or arrows: fallback gaze direction.
+- F / R: raise / lower mock focus.
+- C / X: raise / lower mock calm.
+- B: mock blink.
+- Blink gates: first hold focus until the lock reaches 100%, then blink or press B.
+- Escape: return to the gallery.
+- Reset maze: restart the run and clear opened gates.
+
+## Metrics
+
+The experience tracks gates opened, gate attempts, false triggers, average gate
+open time, and full maze completion time.

--- a/dashboard/src/experiences/orb-control/OrbControl.tsx
+++ b/dashboard/src/experiences/orb-control/OrbControl.tsx
@@ -21,13 +21,15 @@ type MockSignalControls = {
   focus: number;
   calm: number;
   artifact: number;
-  blink: boolean;
 };
 
-type LogEntry = {
-  t: number;
-  action: string;
-  result?: string;
+type LogAction = "orb_grabbed" | "orb_released" | "release_failed" | "orb_unstable";
+
+type MetricTotals = {
+  grabs: number;
+  releases: number;
+  failed: number;
+  unstable: number;
 };
 
 type ReleasePulse = {
@@ -82,9 +84,8 @@ function useKeyboardGaze(onExit: () => void) {
     focus: 0,
     calm: 0,
     artifact: 0,
-    blink: false,
   });
-  const blinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mockBlinkQueuedRef = useRef(false);
 
   useEffect(() => {
     const dirOf = (key: string): keyof typeof keysRef.current | null => {
@@ -125,11 +126,7 @@ function useKeyboardGaze(onExit: () => void) {
       else if (key === "n") mock.artifact = clamp(mock.artifact + 0.15, 0, 1);
       else if (key === "m") mock.artifact = clamp(mock.artifact - 0.15, 0, 1);
       else if (key === "b") {
-        mock.blink = true;
-        if (blinkTimerRef.current) clearTimeout(blinkTimerRef.current);
-        blinkTimerRef.current = setTimeout(() => {
-          mockRef.current.blink = false;
-        }, 180);
+        mockBlinkQueuedRef.current = true;
       }
     };
 
@@ -143,11 +140,10 @@ function useKeyboardGaze(onExit: () => void) {
     return () => {
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
-      if (blinkTimerRef.current) clearTimeout(blinkTimerRef.current);
     };
   }, [onExit]);
 
-  return { keysRef, keyPositionRef, mockRef };
+  return { keysRef, keyPositionRef, mockRef, mockBlinkQueuedRef };
 }
 
 function Meter({
@@ -175,18 +171,13 @@ function Meter({
   );
 }
 
-function Metrics({ entries }: { entries: LogEntry[] }) {
-  const grabs = entries.filter((e) => e.action === "orb_grabbed").length;
-  const releases = entries.filter((e) => e.action === "orb_released").length;
-  const failed = entries.filter((e) => e.action === "release_failed").length;
-  const unstable = entries.filter((e) => e.action === "orb_unstable").length;
-
+function Metrics({ totals }: { totals: MetricTotals }) {
   return (
     <div style={styles.metrics}>
-      <Metric label="Grabs" value={String(grabs)} />
-      <Metric label="Releases" value={String(releases)} />
-      <Metric label="Failed blinks" value={String(failed)} />
-      <Metric label="Instability" value={String(unstable)} />
+      <Metric label="Grabs" value={String(totals.grabs)} />
+      <Metric label="Releases" value={String(totals.releases)} />
+      <Metric label="Failed blinks" value={String(totals.failed)} />
+      <Metric label="Instability" value={String(totals.unstable)} />
     </div>
   );
 }
@@ -205,13 +196,14 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
   const { state: focusState, calibrate: calibrateFocus } = useFocus(eegData);
   const { state: relaxState, calibrate: calibrateRelax } = useRelax(eegData);
   const { state: blinkState } = useBlink(eegData);
-  const { keysRef, keyPositionRef, mockRef } = useKeyboardGaze(onExit);
+  const { keysRef, keyPositionRef, mockRef, mockBlinkQueuedRef } = useKeyboardGaze(onExit);
 
   const phaseRef = useRef<"calibrating" | "playing">("calibrating");
   const chargeRef = useRef(0);
   const cooldownRef = useRef(0);
   const grabArmedRef = useRef(true);
   const unstableArmedRef = useRef(true);
+  const lastBlinkCountRef = useRef(blinkState.current.count);
   const lastTickRef = useRef(performance.now());
 
   const [phase, setPhase] = useState<"calibrating" | "playing">("calibrating");
@@ -228,7 +220,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
   const [state, setState] = useState<OrbState>("idle");
   const [speed, setSpeed] = useState(0.7);
   const [eogResponse, setEogResponse] = useState(1);
-  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [totals, setTotals] = useState<MetricTotals>({ grabs: 0, releases: 0, failed: 0, unstable: 0 });
   const [pulses, setPulses] = useState<ReleasePulse[]>([]);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsOpen, setControlsOpen] = useState(true);
@@ -261,8 +253,13 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
     }
   };
 
-  const log = (action: string, result?: string) => {
-    setEntries((prev) => [...prev, { t: Date.now(), action, result }].slice(-200));
+  const log = (action: LogAction) => {
+    setTotals((prev) => ({
+      grabs: prev.grabs + (action === "orb_grabbed" ? 1 : 0),
+      releases: prev.releases + (action === "orb_released" ? 1 : 0),
+      failed: prev.failed + (action === "release_failed" ? 1 : 0),
+      unstable: prev.unstable + (action === "orb_unstable" ? 1 : 0),
+    }));
   };
 
   useEffect(() => {
@@ -276,6 +273,12 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
       const eog = readEog(eegData, sampleRate, eogResponse);
       const keys = keysRef.current;
       const mock = mockRef.current;
+      const blinkCount = blinkState.current.count;
+      const hardwareBlink = blinkCount > lastBlinkCountRef.current;
+      lastBlinkCountRef.current = blinkCount;
+      const mockBlink = mockBlinkQueuedRef.current;
+      const blinkNow = hardwareBlink || mockBlink;
+      if (mockBlink) mockBlinkQueuedRef.current = false;
       const keyGaze = {
         x: (keys.right ? 1 : 0) - (keys.left ? 1 : 0),
         y: (keys.up ? 1 : 0) - (keys.down ? 1 : 0),
@@ -290,7 +293,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
       const frame: SignalFrame = {
         focus: Math.max(focusState.current.focus, mock.focus),
         calm: Math.max(relaxState.current.relaxation, mock.calm),
-        blink: blinkState.current.blinked || mock.blink,
+        blink: blinkNow,
         calibration:
           focusState.current.calibrated || relaxState.current.calibrated || phaseRef.current === "playing"
             ? 1
@@ -331,7 +334,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
       if (unstable && grabbed) {
         if (unstableArmedRef.current) {
           unstableArmedRef.current = false;
-          log("orb_unstable", "artifact above threshold");
+          log("orb_unstable");
         }
       } else unstableArmedRef.current = true;
 
@@ -339,7 +342,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
         if (chargeRef.current >= RELEASE_CHARGE) {
           const x = grabbed ? clamp(50 + frame.gazeX * 48, 3, 97) : 50;
           const y = grabbed ? clamp(50 - frame.gazeY * 44, 3, 97) : 50;
-          log("orb_released", `${Math.round(chargeRef.current * 100)}%`);
+          log("orb_released");
           setPulses((prev) => [...prev.slice(-5), { id: Date.now(), x, y }]);
           chargeRef.current = 0;
           grabArmedRef.current = true;
@@ -349,7 +352,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
           raf = requestAnimationFrame(loop);
           return;
         }
-        log("release_failed", "charge below threshold");
+        log("release_failed");
       }
 
       if (unstable && grabbed) setState("unstable");
@@ -369,6 +372,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
     focusState,
     keyPositionRef,
     keysRef,
+    mockBlinkQueuedRef,
     relaxState,
     sampleRate,
     speed,
@@ -510,7 +514,7 @@ export default function OrbControl({ eegData, onExit }: ExperienceProps) {
           </aside>
         </main>
 
-        <Metrics entries={entries} />
+        <Metrics totals={totals} />
       </div>
 
       <style>{`

--- a/dashboard/src/experiences/orb-control/OrbControl.tsx
+++ b/dashboard/src/experiences/orb-control/OrbControl.tsx
@@ -1,0 +1,774 @@
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import type { ExperienceProps } from "../registry";
+import type { EEGData } from "../../types";
+import { useBlink, useFocus, useRelax } from "../../hooks/detectors";
+import { useSampleRate } from "../../lib/sampleRateStore";
+
+type OrbState = "idle" | "grabbed" | "charging" | "unstable" | "released";
+
+type SignalFrame = {
+  focus: number;
+  calm: number;
+  blink: boolean;
+  calibration: number;
+  artifact: number;
+  gazeX: number;
+  gazeY: number;
+};
+
+type MockSignalControls = {
+  focus: number;
+  calm: number;
+  artifact: number;
+  blink: boolean;
+};
+
+type LogEntry = {
+  t: number;
+  action: string;
+  result?: string;
+};
+
+type ReleasePulse = {
+  id: number;
+  x: number;
+  y: number;
+};
+
+const CHARGE_FOCUS = 0.32;
+const RELEASE_CHARGE = 0.72;
+const CALM_STEADY = 0.6;
+const UNSTABLE_ARTIFACT = 0.4;
+const CHARGE_RATE = 0.62;
+const COOLDOWN = 1.2;
+
+const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+const pct = (v: number) => `${Math.round(clamp(v, 0, 1) * 100)}%`;
+
+function readEog(eegData: EEGData, sampleRate: number, response: number) {
+  const buffers = eegData.buffers.current;
+  if (buffers.length < 2) return { x: 0, y: 0 };
+
+  const windowSamples = Math.max(8, Math.round(sampleRate * 0.12));
+  if (eegData.samplesInBuffer.current < windowSamples) return { x: 0, y: 0 };
+
+  const fp1 = buffers[0];
+  const fp2 = buffers[1];
+  const wi = eegData.writeIndex.current;
+  const bs = eegData.bufferSize;
+  let sumH = 0;
+  let sumV = 0;
+
+  for (let i = 0; i < windowSamples; i++) {
+    const idx = (wi - windowSamples + i + bs) % bs;
+    const v1 = fp1[idx] ?? 0;
+    const v2 = fp2[idx] ?? 0;
+    sumH += v2 - v1;
+    sumV += (v1 + v2) * 0.5;
+  }
+
+  const scale = 120 / Math.max(0.25, response);
+  return {
+    x: clamp(sumH / windowSamples / scale, -1, 1),
+    y: clamp(-(sumV / windowSamples / scale), -1, 1),
+  };
+}
+
+function useKeyboardGaze(onExit: () => void) {
+  const keysRef = useRef({ up: false, down: false, left: false, right: false });
+  const keyPositionRef = useRef({ x: 0, y: 0 });
+  const mockRef = useRef<MockSignalControls>({
+    focus: 0,
+    calm: 0,
+    artifact: 0,
+    blink: false,
+  });
+  const blinkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const dirOf = (key: string): keyof typeof keysRef.current | null => {
+      switch (key.toLowerCase()) {
+        case "arrowup":
+        case "w":
+          return "up";
+        case "arrowdown":
+        case "s":
+          return "down";
+        case "arrowleft":
+        case "a":
+          return "left";
+        case "arrowright":
+        case "d":
+          return "right";
+        default:
+          return null;
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onExit();
+      const dir = dirOf(e.key);
+      if (dir) {
+        e.preventDefault();
+        keysRef.current[dir] = true;
+        return;
+      }
+
+      if (e.repeat) return;
+      const key = e.key.toLowerCase();
+      const mock = mockRef.current;
+      if (key === "f") mock.focus = clamp(mock.focus + 0.15, 0, 1);
+      else if (key === "r") mock.focus = clamp(mock.focus - 0.15, 0, 1);
+      else if (key === "c") mock.calm = clamp(mock.calm + 0.15, 0, 1);
+      else if (key === "x") mock.calm = clamp(mock.calm - 0.15, 0, 1);
+      else if (key === "n") mock.artifact = clamp(mock.artifact + 0.15, 0, 1);
+      else if (key === "m") mock.artifact = clamp(mock.artifact - 0.15, 0, 1);
+      else if (key === "b") {
+        mock.blink = true;
+        if (blinkTimerRef.current) clearTimeout(blinkTimerRef.current);
+        blinkTimerRef.current = setTimeout(() => {
+          mockRef.current.blink = false;
+        }, 180);
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      const dir = dirOf(e.key);
+      if (dir) keysRef.current[dir] = false;
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      if (blinkTimerRef.current) clearTimeout(blinkTimerRef.current);
+    };
+  }, [onExit]);
+
+  return { keysRef, keyPositionRef, mockRef };
+}
+
+function Meter({
+  label,
+  value,
+  color,
+  threshold,
+}: {
+  label: string;
+  value: number;
+  color: string;
+  threshold?: number;
+}) {
+  return (
+    <div style={styles.meter}>
+      <div style={styles.meterTop}>
+        <span>{label}</span>
+        <span>{pct(value)}</span>
+      </div>
+      <div style={styles.track}>
+        {threshold !== undefined && <span style={{ ...styles.tick, left: pct(threshold) }} />}
+        <span style={{ ...styles.fill, width: pct(value), background: color }} />
+      </div>
+    </div>
+  );
+}
+
+function Metrics({ entries }: { entries: LogEntry[] }) {
+  const grabs = entries.filter((e) => e.action === "orb_grabbed").length;
+  const releases = entries.filter((e) => e.action === "orb_released").length;
+  const failed = entries.filter((e) => e.action === "release_failed").length;
+  const unstable = entries.filter((e) => e.action === "orb_unstable").length;
+
+  return (
+    <div style={styles.metrics}>
+      <Metric label="Grabs" value={String(grabs)} />
+      <Metric label="Releases" value={String(releases)} />
+      <Metric label="Failed blinks" value={String(failed)} />
+      <Metric label="Instability" value={String(unstable)} />
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={styles.metric}>
+      <span style={styles.metricLabel}>{label}</span>
+      <span style={styles.metricValue}>{value}</span>
+    </div>
+  );
+}
+
+export default function OrbControl({ eegData, onExit }: ExperienceProps) {
+  const sampleRate = useSampleRate();
+  const { state: focusState, calibrate: calibrateFocus } = useFocus(eegData);
+  const { state: relaxState, calibrate: calibrateRelax } = useRelax(eegData);
+  const { state: blinkState } = useBlink(eegData);
+  const { keysRef, keyPositionRef, mockRef } = useKeyboardGaze(onExit);
+
+  const phaseRef = useRef<"calibrating" | "playing">("calibrating");
+  const chargeRef = useRef(0);
+  const cooldownRef = useRef(0);
+  const grabArmedRef = useRef(true);
+  const unstableArmedRef = useRef(true);
+  const lastTickRef = useRef(performance.now());
+
+  const [phase, setPhase] = useState<"calibrating" | "playing">("calibrating");
+  const [signal, setSignal] = useState<SignalFrame>({
+    focus: 0,
+    calm: 0,
+    blink: false,
+    calibration: 0,
+    artifact: 0,
+    gazeX: 0,
+    gazeY: 0,
+  });
+  const [charge, setCharge] = useState(0);
+  const [state, setState] = useState<OrbState>("idle");
+  const [speed, setSpeed] = useState(0.7);
+  const [eogResponse, setEogResponse] = useState(1);
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [pulses, setPulses] = useState<ReleasePulse[]>([]);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [controlsOpen, setControlsOpen] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([calibrateFocus(), calibrateRelax()]).finally(() => {
+      if (!cancelled) {
+        phaseRef.current = "playing";
+        setPhase("playing");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [calibrateFocus, calibrateRelax]);
+
+  useEffect(() => {
+    const onFullscreenChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = async () => {
+    try {
+      if (document.fullscreenElement) await document.exitFullscreen();
+      else await document.documentElement.requestFullscreen();
+    } catch {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    }
+  };
+
+  const log = (action: string, result?: string) => {
+    setEntries((prev) => [...prev, { t: Date.now(), action, result }].slice(-200));
+  };
+
+  useEffect(() => {
+    let raf = 0;
+
+    const loop = () => {
+      const now = performance.now();
+      const dt = Math.min((now - lastTickRef.current) / 1000, 0.1);
+      lastTickRef.current = now;
+
+      const eog = readEog(eegData, sampleRate, eogResponse);
+      const keys = keysRef.current;
+      const mock = mockRef.current;
+      const keyGaze = {
+        x: (keys.right ? 1 : 0) - (keys.left ? 1 : 0),
+        y: (keys.up ? 1 : 0) - (keys.down ? 1 : 0),
+      };
+      const hasKeys = keyGaze.x !== 0 || keyGaze.y !== 0;
+      if (hasKeys) {
+        const keyboardStep = dt * 0.72 * speed;
+        keyPositionRef.current.x = clamp(keyPositionRef.current.x + keyGaze.x * keyboardStep, -1, 1);
+        keyPositionRef.current.y = clamp(keyPositionRef.current.y + keyGaze.y * keyboardStep, -1, 1);
+      }
+      const hasEog = Math.abs(eog.x) > 0.05 || Math.abs(eog.y) > 0.05;
+      const frame: SignalFrame = {
+        focus: Math.max(focusState.current.focus, mock.focus),
+        calm: Math.max(relaxState.current.relaxation, mock.calm),
+        blink: blinkState.current.blinked || mock.blink,
+        calibration:
+          focusState.current.calibrated || relaxState.current.calibrated || phaseRef.current === "playing"
+            ? 1
+            : 0.15,
+        artifact: Math.max(clamp(blinkState.current.amplitude / 350, 0, 1), mock.artifact),
+        gazeX: hasKeys ? keyPositionRef.current.x : hasEog ? clamp(eog.x * speed, -1, 1) : keyPositionRef.current.x,
+        gazeY: hasKeys ? keyPositionRef.current.y : hasEog ? clamp(eog.y * speed, -1, 1) : keyPositionRef.current.y,
+      };
+      setSignal(frame);
+
+      if (phaseRef.current !== "playing") {
+        raf = requestAnimationFrame(loop);
+        return;
+      }
+
+      if (cooldownRef.current > 0) {
+        cooldownRef.current = Math.max(0, cooldownRef.current - dt);
+        setState("released");
+        setCharge(chargeRef.current);
+        raf = requestAnimationFrame(loop);
+        return;
+      }
+
+      const grabbed = frame.focus > CHARGE_FOCUS;
+      const unstable = frame.artifact > UNSTABLE_ARTIFACT && frame.calm < CALM_STEADY;
+
+      if (grabbed) {
+        if (grabArmedRef.current) {
+          grabArmedRef.current = false;
+          log("orb_grabbed");
+        }
+        chargeRef.current = Math.min(1, chargeRef.current + dt * CHARGE_RATE * frame.focus);
+      } else {
+        chargeRef.current = Math.max(0, chargeRef.current - dt * 0.42);
+        if (chargeRef.current <= 0) grabArmedRef.current = true;
+      }
+
+      if (unstable && grabbed) {
+        if (unstableArmedRef.current) {
+          unstableArmedRef.current = false;
+          log("orb_unstable", "artifact above threshold");
+        }
+      } else unstableArmedRef.current = true;
+
+      if (frame.blink) {
+        if (chargeRef.current >= RELEASE_CHARGE) {
+          const x = grabbed ? clamp(50 + frame.gazeX * 48, 3, 97) : 50;
+          const y = grabbed ? clamp(50 - frame.gazeY * 44, 3, 97) : 50;
+          log("orb_released", `${Math.round(chargeRef.current * 100)}%`);
+          setPulses((prev) => [...prev.slice(-5), { id: Date.now(), x, y }]);
+          chargeRef.current = 0;
+          grabArmedRef.current = true;
+          cooldownRef.current = COOLDOWN;
+          setCharge(0);
+          setState("released");
+          raf = requestAnimationFrame(loop);
+          return;
+        }
+        log("release_failed", "charge below threshold");
+      }
+
+      if (unstable && grabbed) setState("unstable");
+      else if (grabbed) setState(chargeRef.current >= RELEASE_CHARGE ? "charging" : "grabbed");
+      else setState("idle");
+
+      setCharge(chargeRef.current);
+      raf = requestAnimationFrame(loop);
+    };
+
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [
+    blinkState,
+    eegData,
+    eogResponse,
+    focusState,
+    keyPositionRef,
+    keysRef,
+    relaxState,
+    sampleRate,
+    speed,
+  ]);
+
+  const startAnyway = () => {
+    phaseRef.current = "playing";
+    setPhase("playing");
+  };
+
+  const active = signal.focus > CHARGE_FOCUS;
+  const unstable = signal.artifact > UNSTABLE_ARTIFACT && signal.calm < CALM_STEADY;
+  const x = active ? clamp(50 + signal.gazeX * 48, 3, 97) : 50;
+  const y = active ? clamp(50 - signal.gazeY * 44, 3, 97) : 50;
+  const ready = charge >= RELEASE_CHARGE;
+
+  return (
+    <div style={styles.root}>
+      <button onClick={onExit} style={styles.exitButton}>Exit</button>
+
+      <div style={styles.appShell}>
+        <header style={styles.header}>
+          <div>
+            <div style={styles.eyebrow}>BCI / EOG continuous control</div>
+            <h1 style={styles.title}>Orb Control</h1>
+            <p style={styles.subtitle}>
+              Focus grabs and charges the orb, EOG gaze moves it through space,
+              calm stabilizes the field, and a blink releases the stored charge.
+            </p>
+          </div>
+          <div style={styles.headerActions}>
+            <button onClick={() => setControlsOpen((open) => !open)} style={styles.secondaryButton}>
+              {controlsOpen ? "Hide controls" : "Show controls"}
+            </button>
+            <button onClick={toggleFullscreen} style={styles.secondaryButton}>
+              {isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            </button>
+            <div style={styles.stateBadge}>{state.toUpperCase()}</div>
+          </div>
+        </header>
+
+        <main style={{ ...styles.main, ...(controlsOpen ? {} : styles.mainControlsHidden) }}>
+          <section style={styles.stage}>
+            <div style={styles.stageGrid} />
+            <div style={styles.axisLineH} />
+            <div style={styles.axisLineV} />
+            <div style={styles.stageCaption}>
+              <span>Hold focus to grab</span>
+              <span>Move with gaze</span>
+              <span>{ready ? "Blink to release" : "Build charge"}</span>
+            </div>
+
+            {pulses.map((pulse) => (
+              <span
+                key={pulse.id}
+                style={{
+                  ...styles.releasePulse,
+                  left: `${pulse.x}%`,
+                  top: `${pulse.y}%`,
+                }}
+              />
+            ))}
+
+            <div
+              style={{
+                ...styles.orbCarrier,
+                left: `${x}%`,
+                top: `${y}%`,
+                transition: `left ${Math.max(0.035, 0.12 / speed)}s linear, top ${Math.max(0.035, 0.12 / speed)}s linear`,
+                animation: unstable && active ? "orbShake 90ms infinite" : undefined,
+              }}
+            >
+              <div
+                style={{
+                  ...styles.stabilityAura,
+                  opacity: active ? 0.12 + signal.calm * 0.68 : 0.08,
+                  transform: `translate(-50%, -50%) scale(${1 + signal.calm * 1.25})`,
+                }}
+              />
+              <div
+                style={{
+                  ...styles.chargeRing,
+                  opacity: active ? 0.42 + charge * 0.58 : 0.22,
+                  borderColor: ready ? "rgba(134,239,172,0.95)" : `rgba(103,232,249,${0.34 + charge * 0.5})`,
+                  transform: `translate(-50%, -50%) scale(${1 + charge * 0.45}) rotate(${charge * 250}deg)`,
+                }}
+              />
+              <div
+                style={{
+                  ...styles.orb,
+                  opacity: active ? 1 : 0.52,
+                  transform: `translate(-50%, -50%) scale(${0.85 + charge * 0.42})`,
+                  boxShadow: ready
+                    ? "0 0 86px 28px rgba(134,239,172,0.36), inset 0 0 34px rgba(255,255,255,0.36)"
+                    : `0 0 ${28 + charge * 72}px ${8 + charge * 22}px rgba(103,232,249,${0.18 + charge * 0.28})`,
+                }}
+              />
+            </div>
+          </section>
+
+          <aside style={{ ...styles.panel, ...(controlsOpen ? {} : styles.panelHidden) }} aria-hidden={!controlsOpen}>
+            <div style={styles.panelLabel}>Orb console</div>
+
+            <label style={styles.slider}>
+              <span>Gaze speed {speed.toFixed(1)}x</span>
+              <input
+                type="range"
+                min={0.3}
+                max={2}
+                step={0.1}
+                value={speed}
+                onChange={(e) => setSpeed(Number(e.currentTarget.value))}
+              />
+            </label>
+
+            <label style={styles.slider}>
+              <span>EOG response {eogResponse.toFixed(1)}x</span>
+              <input
+                type="range"
+                min={0.5}
+                max={3}
+                step={0.1}
+                value={eogResponse}
+                onChange={(e) => setEogResponse(Number(e.currentTarget.value))}
+              />
+            </label>
+
+            <Meter label="Focus grab" value={signal.focus} threshold={CHARGE_FOCUS} color="#67e8f9" />
+            <Meter label="Stored charge" value={charge} threshold={RELEASE_CHARGE} color="#86efac" />
+            <Meter label="Calm stability" value={signal.calm} threshold={CALM_STEADY} color="#a7f3d0" />
+            <Meter label="Artifact" value={signal.artifact} threshold={UNSTABLE_ARTIFACT} color="#fb7185" />
+            <Meter label="Gaze X" value={(signal.gazeX + 1) / 2} color="#facc15" />
+            <Meter label="Gaze Y" value={(signal.gazeY + 1) / 2} color="#facc15" />
+
+            <p style={styles.hint}>
+              Mock controls: hold WASD/arrows to move, F/R focus, C/X calm, B blink, N/M artifact.
+              Hardware focus, calm, blink, and EOG are read from PiEEG detector hooks when available.
+            </p>
+          </aside>
+        </main>
+
+        <Metrics entries={entries} />
+      </div>
+
+      <style>{`
+        @keyframes orbShake {
+          0% { transform: translate(-50%, -50%) translate(0, 0); }
+          33% { transform: translate(-50%, -50%) translate(4px, -2px); }
+          66% { transform: translate(-50%, -50%) translate(-3px, 3px); }
+          100% { transform: translate(-50%, -50%) translate(0, 0); }
+        }
+        @keyframes pulseOut {
+          0% { opacity: 0.85; transform: translate(-50%, -50%) scale(0.2); }
+          100% { opacity: 0; transform: translate(-50%, -50%) scale(2.4); }
+        }
+      `}</style>
+
+      {phase === "calibrating" && (
+        <div style={styles.overlay}>
+          <div style={styles.overlayCard}>
+            <h2 style={styles.overlayTitle}>Calibrating baseline</h2>
+            <p style={styles.hint}>Sit still for about three seconds while focus and relaxation baselines warm up.</p>
+            <button onClick={startAnyway} style={styles.primaryButton}>Start anyway</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  root: {
+    position: "fixed",
+    inset: 0,
+    overflow: "auto",
+    color: "#f8fbff",
+    background:
+      "radial-gradient(circle at 72% 12%, rgba(34,211,238,0.18), transparent 28%), linear-gradient(135deg, #04111f 0%, #111827 46%, #020617 100%)",
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+    padding: 24,
+  },
+  appShell: {
+    width: "min(100%, 1320px)",
+    minHeight: "calc(100vh - 48px)",
+    margin: "0 auto",
+    display: "flex",
+    flexDirection: "column",
+    gap: 18,
+  },
+  exitButton: {
+    position: "absolute",
+    top: 16,
+    left: 16,
+    zIndex: 5,
+    border: "1px solid rgba(255,255,255,0.22)",
+    background: "rgba(2,6,23,0.72)",
+    color: "#f8fbff",
+    borderRadius: 6,
+    padding: "8px 12px",
+    cursor: "pointer",
+  },
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 16,
+    alignItems: "flex-start",
+    margin: "8px 0 0 72px",
+  },
+  eyebrow: { color: "#67e8f9", fontSize: 12, textTransform: "uppercase", letterSpacing: 0 },
+  title: { margin: "2px 0 4px", fontSize: 34, lineHeight: 1.05 },
+  subtitle: { maxWidth: 840, margin: 0, color: "#cbd5e1", lineHeight: 1.45 },
+  headerActions: { display: "flex", gap: 10, alignItems: "center", justifyContent: "flex-end", flexWrap: "wrap" },
+  secondaryButton: {
+    border: "1px solid rgba(255,255,255,0.22)",
+    background: "rgba(15,23,42,0.85)",
+    color: "#f8fbff",
+    borderRadius: 6,
+    padding: "10px 14px",
+    cursor: "pointer",
+  },
+  stateBadge: {
+    border: "1px solid rgba(103,232,249,0.36)",
+    color: "#cffafe",
+    background: "rgba(8,47,73,0.45)",
+    borderRadius: 6,
+    padding: "10px 12px",
+    fontWeight: 800,
+  },
+  main: {
+    display: "grid",
+    gridTemplateColumns: "minmax(760px, 1fr) 340px",
+    gap: 22,
+    alignItems: "stretch",
+    justifyContent: "center",
+    transition: "grid-template-columns 180ms ease",
+  },
+  mainControlsHidden: {
+    gridTemplateColumns: "minmax(760px, 1fr) 0px",
+    gap: 0,
+  },
+  stage: {
+    position: "relative",
+    height: "calc(100vh - 238px)",
+    minHeight: 560,
+    overflow: "hidden",
+    border: "1px solid rgba(103,232,249,0.18)",
+    borderRadius: 8,
+    background:
+      "radial-gradient(circle at 50% 50%, rgba(103,232,249,0.13), transparent 38%), linear-gradient(180deg, rgba(15,23,42,0.22), rgba(2,6,23,0.76))",
+    boxShadow: "inset 0 0 90px rgba(2,6,23,0.9), 0 18px 60px rgba(0,0,0,0.28)",
+  },
+  stageGrid: {
+    position: "absolute",
+    inset: 0,
+    backgroundImage:
+      "linear-gradient(rgba(148,163,184,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(148,163,184,0.08) 1px, transparent 1px)",
+    backgroundSize: "48px 48px",
+    maskImage: "radial-gradient(circle at center, black, transparent 82%)",
+    pointerEvents: "none",
+  },
+  axisLineH: {
+    position: "absolute",
+    left: "8%",
+    right: "8%",
+    top: "50%",
+    height: 1,
+    background: "linear-gradient(90deg, transparent, rgba(103,232,249,0.18), transparent)",
+  },
+  axisLineV: {
+    position: "absolute",
+    top: "8%",
+    bottom: "8%",
+    left: "50%",
+    width: 1,
+    background: "linear-gradient(180deg, transparent, rgba(103,232,249,0.18), transparent)",
+  },
+  stageCaption: {
+    position: "absolute",
+    left: 18,
+    right: 18,
+    bottom: 16,
+    display: "flex",
+    justifyContent: "center",
+    gap: 10,
+    color: "rgba(226,232,240,0.72)",
+    fontSize: 12,
+    pointerEvents: "none",
+  },
+  releasePulse: {
+    position: "absolute",
+    width: 120,
+    height: 120,
+    borderRadius: "50%",
+    border: "2px solid rgba(134,239,172,0.78)",
+    boxShadow: "0 0 42px rgba(134,239,172,0.28)",
+    animation: "pulseOut 900ms ease-out forwards",
+    pointerEvents: "none",
+  },
+  orbCarrier: { position: "absolute", width: 1, height: 1 },
+  stabilityAura: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 190,
+    height: 190,
+    borderRadius: "50%",
+    background: "radial-gradient(circle, rgba(134,239,172,0.28), transparent 68%)",
+    pointerEvents: "none",
+  },
+  chargeRing: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 138,
+    height: 138,
+    borderRadius: "50%",
+    border: "2px solid rgba(103,232,249,0.3)",
+    borderTopColor: "rgba(255,255,255,0.92)",
+    boxShadow: "0 0 22px rgba(103,232,249,0.16)",
+    pointerEvents: "none",
+  },
+  orb: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 104,
+    height: 104,
+    borderRadius: "50%",
+    background:
+      "radial-gradient(circle at 30% 24%, #fff 0 8%, #a5f3fc 18%, #22d3ee 40%, #2563eb 72%, #0f172a 100%)",
+  },
+  panel: {
+    background: "rgba(2,6,23,0.72)",
+    border: "1px solid rgba(148,163,184,0.22)",
+    borderRadius: 8,
+    padding: 18,
+    boxShadow: "0 18px 60px rgba(0,0,0,0.28)",
+    alignSelf: "stretch",
+    overflow: "hidden",
+    opacity: 1,
+    transition: "opacity 160ms ease, transform 180ms ease, padding 180ms ease, border-width 180ms ease",
+  },
+  panelHidden: {
+    opacity: 0,
+    transform: "translateX(18px)",
+    pointerEvents: "none",
+    padding: 0,
+    borderWidth: 0,
+  },
+  panelLabel: { color: "#67e8f9", fontSize: 12, textTransform: "uppercase", letterSpacing: 0, marginBottom: 10 },
+  slider: { display: "grid", gap: 8, margin: "12px 0", color: "#dbeafe", fontSize: 13 },
+  meter: { marginTop: 14 },
+  meterTop: { display: "flex", justifyContent: "space-between", fontSize: 12, color: "#dbeafe", marginBottom: 5 },
+  track: { position: "relative", height: 8, borderRadius: 999, background: "rgba(148,163,184,0.2)", overflow: "hidden" },
+  fill: { display: "block", height: "100%", borderRadius: 999, transition: "width 100ms linear" },
+  tick: { position: "absolute", top: 0, bottom: 0, width: 2, background: "#fff", opacity: 0.7, zIndex: 1 },
+  hint: { margin: "14px 0 0", color: "#cbd5e1", lineHeight: 1.45, fontSize: 13 },
+  metrics: {
+    display: "grid",
+    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+    gap: 10,
+    marginBottom: 6,
+  },
+  metric: {
+    minHeight: 48,
+    padding: "10px 12px",
+    background: "rgba(2,6,23,0.72)",
+    border: "1px solid rgba(148,163,184,0.2)",
+    borderRadius: 8,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  metricValue: { display: "block", fontSize: 20, fontWeight: 800, color: "#f8fbff" },
+  metricLabel: { display: "block", color: "#cbd5e1", fontSize: 12, textTransform: "uppercase", letterSpacing: 0 },
+  overlay: {
+    position: "absolute",
+    inset: 0,
+    display: "grid",
+    placeItems: "center",
+    background: "rgba(2,6,23,0.76)",
+    zIndex: 10,
+  },
+  overlayCard: {
+    width: "min(420px, calc(100vw - 40px))",
+    borderRadius: 8,
+    border: "1px solid rgba(103,232,249,0.36)",
+    padding: 22,
+    background: "#111827",
+    boxShadow: "0 24px 80px rgba(0,0,0,0.42)",
+  },
+  overlayTitle: { margin: "0 0 8px", fontSize: 24 },
+  primaryButton: {
+    border: 0,
+    background: "#67e8f9",
+    color: "#06121f",
+    borderRadius: 6,
+    padding: "10px 14px",
+    fontWeight: 800,
+    cursor: "pointer",
+  },
+};

--- a/dashboard/src/experiences/orb-control/README.md
+++ b/dashboard/src/experiences/orb-control/README.md
@@ -1,0 +1,51 @@
+# Orb Control
+
+Orb Control is a continuous BCI/EOG control demo for the PiEEG dashboard
+experiences gallery. The user moves an orb with EOG gaze, builds charge with
+focus, steadies it with calm, and releases stored charge with a blink.
+
+## Signal mapping
+
+| Signal | Effect |
+| --- | --- |
+| Focus above 0.32 | Grabs the orb and builds stored charge |
+| EOG gaze X/Y | Moves the orb around the stage |
+| Calm above 0.6 | Stabilizes the orb aura and suppresses artifact instability |
+| Blink | Releases a pulse if charge is at least 72% |
+| Blink below 72% | Logs a failed release |
+| High blink amplitude/artifact | Shakes the orb unless calm is high |
+
+## PiEEG integration
+
+- Uses `useFocus(eegData)` for orb grab and charge.
+- Uses `useRelax(eegData)` for stability.
+- Uses `useBlink(eegData)` for release.
+- Reads raw EOG from `eegData.buffers.current[0]` and `[1]`:
+  - horizontal = `Fp2 - Fp1`
+  - vertical = `(Fp1 + Fp2) / 2`
+- Includes EOG response and movement speed sliders for mock-mode and hardware
+  tuning. Higher EOG response means stronger gaze movement.
+- Includes WASD/arrow fallback for local testing without EOG-like mock samples.
+- Includes mock signal keys for local testing because PiEEG mock mode does not
+  provide per-experience sliders.
+
+## Controls
+
+- Gaze speed: tune movement responsiveness.
+- EOG response: tune raw frontal-channel movement amplitude.
+- WASD or arrows: fallback gaze direction.
+- F / R: raise / lower mock focus.
+- C / X: raise / lower mock calm.
+- B: mock blink.
+- N / M: raise / lower mock artifact.
+- Escape: return to the gallery.
+
+Artifact is derived from frontal-channel blink amplitude plus the N/M mock
+control. It is not a separate PiEEG protocol field; it represents blink or
+muscle contamination in Fp1/Fp2 that makes the orb unstable unless relaxation is
+high enough to steady it.
+
+## Metrics
+
+The experience tracks orb grabs, successful releases, failed blink releases, and
+unstable periods.

--- a/dashboard/src/experiences/registry.ts
+++ b/dashboard/src/experiences/registry.ts
@@ -89,6 +89,12 @@ const FaceTrainerV2Experience = lazy(
 const PenaltyShootersExperience = lazy(
   () => import("./penalty-shooters/PenaltyShooters"),
 );
+const NeuralMazeLockExperience = lazy(
+  () => import("./neural-maze-lock/NeuralMazeLock"),
+);
+const OrbControlExperience = lazy(
+  () => import("./orb-control/OrbControl"),
+);
 
 export const EXPERIENCES: ExperienceEntry[] = [
   {
@@ -264,6 +270,26 @@ export const EXPERIENCES: ExperienceEntry[] = [
     tag: "BCI / Game",
     gradient: ["#22c55e", "#f59e0b"],
     component: PenaltyShootersExperience,
+    author: "PiEEG community",
+  },
+  {
+    id: "neural-maze-lock",
+    name: "Neural Maze Lock",
+    description:
+      "Navigate a maze by EOG gaze while focus, calm, and blink gates test neural intent-confirmation. Tracks false triggers, gate attempts, gate-open time, and maze completion time.",
+    tag: "BCI / Game",
+    gradient: ["#67e8f9", "#1d4ed8"],
+    component: NeuralMazeLockExperience,
+    author: "PiEEG community",
+  },
+  {
+    id: "orb-control",
+    name: "Orb Control",
+    description:
+      "Control an energy orb with PiEEG signals: focus grabs and charges it, EOG gaze moves it, calm steadies it, frontal artifacts destabilize it, and a blink releases stored charge.",
+    tag: "BCI / EOG",
+    gradient: ["#a855f7", "#22d3ee"],
+    component: OrbControlExperience,
     author: "PiEEG community",
   },
 ];


### PR DESCRIPTION
## What changed

Added two new PiEEG dashboard experiences:

- Neural Maze Lock
- Orb Control

Neural Maze Lock is a small maze game where EOG/WASD moves the player, and focus, calm, and blink signals open different locks.

Orb Control is a simple control demo where focus grabs and charges the orb, EOG/WASD moves it, calm stabilizes it, and blink releases the charge.

Both demos include keyboard/mock controls, so they can be tested without PiEEG hardware, but they also use the existing PiEEG hooks for focus, relax, blink, and EOG input.

## Tested

- Ran `npm run build`
- Checked that generated static dashboard files are not included
- Added README files for both experiences

___

Let me know if need to make any more changes. New to ecosystem so don't mind the mistakes. Also, not sure how it works with hardware, I have only used keyboard mock controls to test.