### PR TITLE
fix: graceful error when /dev/gpiochip4 not found on non-Pi hardware

### DIFF
--- a/pieeg_server/hardware.py
+++ b/pieeg_server/hardware.py
@@ -372,7 +372,19 @@ class PiEEGHardware:
     def _init_gpio(self):
         """Initialize GPIO via Linux chardev v1 ioctl (no gpiod dependency)."""
         logger.info("Opening GPIO chip %s", self._gpio_chip_name)
-        self._chip_fd = os.open(self._gpio_chip_name, os.O_RDWR | os.O_CLOEXEC)
+        try:
+            self._chip_fd = os.open(self._gpio_chip_name, os.O_RDWR | os.O_CLOEXEC)
+        except FileNotFoundError:
+            print(
+                "\n  ERROR: GPIO chip not found: {}\n\n"
+                "  PiEEG hardware requires a Raspberry Pi with SPI enabled and\n"
+                "  the PiEEG shield connected. This machine does not appear to\n"
+                "  have the required GPIO hardware.\n\n"
+                "  To run without hardware (synthetic EEG data for testing):\n"
+                "    pieeg-server --mock\n".format(self._gpio_chip_name),
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         # Chip-select line (output, default high). Skipped when the kernel
         # SPI driver owns the line (e.g. Pi 5 in 8-ch mode); see profiles.py.

--- a/pieeg_server/profiles.py
+++ b/pieeg_server/profiles.py
@@ -55,6 +55,34 @@ PROFILES: dict[str, "HardwareProfile"] = {
 DEFAULT_PROFILE = "pi4"
 
 
+def is_raspberry_pi() -> bool:
+    """Check whether we are running on a Raspberry Pi.
+
+    Returns True if /proc/device-tree contains a Raspberry Pi model string
+    or a Broadcom SoC compatible string. This is cheap (two small file reads)
+    and can be called before hardware init to decide between real and mock.
+    """
+    # 1. Model string (most human-readable, set by firmware).
+    try:
+        raw = Path("/proc/device-tree/model").read_bytes()
+        model = raw.rstrip(b"\x00").decode("ascii", errors="replace")
+        if "Raspberry Pi" in model:
+            return True
+    except OSError:
+        pass
+
+    # 2. SoC compatible string (fallback when model is missing/custom).
+    try:
+        raw = Path("/proc/device-tree/compatible").read_bytes()
+        tokens = raw.split(b"\x00")
+        if any(t.startswith(b"bcm2") for t in tokens):
+            return True
+    except OSError:
+        pass
+
+    return False
+
+
 def detect_profile() -> str:
     """Auto-detect a hardware profile name from /proc/device-tree.
 
@@ -87,6 +115,11 @@ def detect_profile() -> str:
     except OSError:
         pass
 
+    logger.warning(
+        "Could not detect a Raspberry Pi — falling back to profile %r. "
+        "If this is not a Pi, use --mock for synthetic data.",
+        DEFAULT_PROFILE,
+    )
     return DEFAULT_PROFILE
 
 


### PR DESCRIPTION
## Problem

`pieeg-server` crashes with a raw `FileNotFoundError` traceback when run on non-Raspberry Pi hardware (e.g., x86_64). The auto-detection silently falls back to profile `pi4`, which tries to open `/dev/gpiochip4` — a device that does not exist.

## Fix

- **`hardware.py`**: `_init_gpio()` now catches `FileNotFoundError` and prints a clear error message suggesting `--mock` mode instead of a raw traceback.
- **`profiles.py`**: Added `is_raspberry_pi()` helper and `detect_profile()` now emits a `WARNING` when it cannot detect a Raspberry Pi, telling the user about `--mock`.

## Before

```
FileNotFoundError: [Errno 2] No such file or directory: /dev/gpiochip4
```

## After

```
WARNING  Could not detect a Raspberry Pi — falling back to profile pi4.
         If this is not a Pi, use --mock for synthetic data.
...
ERROR: GPIO chip not found: /dev/gpiochip4
  PiEEG hardware requires a Raspberry Pi with SPI enabled and
  the PiEEG shield connected. This machine does not appear to
  have the required GPIO hardware.
  To run without hardware (synthetic EEG data for testing):
    pieeg-server --mock
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)